### PR TITLE
feat: 로그인 페이지 modal 형식으로 변경

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 // App.jsx
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { Routes, Route, useLocation } from "react-router-dom";
 
 import DefaultLayout from "./layouts/DefaultLayout";
 import MarginLayout from "./layouts/MarginLayout";
@@ -13,6 +13,7 @@ import SignUpSuccess from "./pages/auth/SignUpSuccess";
 import SignIn from "./pages/auth/SignIn";
 import SignInV2 from "./pages/auth/SignInV2";
 import FindBar from "./pages/auth/FindBar";
+import SignInDialog from "./components/auth/SignInDialog";
 
 import PostGallery from "./pages/work/postList/PostGallery";
 
@@ -47,109 +48,107 @@ import BrowserWarning from "./components/BrowserWarning";
 
 import ProtectedRoute from "./routes/ProtectedRoute";
 
-import { AuthProvider } from "./contexts/AuthContext";
-
 import "./App.css";
 import "./styles/colors.css";
 import "./styles/text.css";
 import "./styles/utilities.css";
 
 function App() {
+  const location = useLocation();
+  const { state } = location;
+
   return (
     <div className="App">
       {/* <BrowserWarning /> */}
-      <BrowserRouter>
-        <AuthProvider>
-          <Routes>
-            <Route path="/" element={<DefaultLayout />}>
-              <Route
-                path="admin/scriptManage"
-                element={<AdminSwitch page={0} />}
-              />
-              <Route
-                path="admin/orderManage"
-                element={<AdminSwitch page={1} />}
-              />
-              <Route
-                path="admin/statisticManage"
-                element={<AdminSwitch page={2} />}
-              />
 
-              <Route index element={<MainVer2 />} />
-              <Route path="v1" element={<MainVer1 />} />
-              <Route path="signup" element={<SignUpDefault />} />
-              <Route path="signup/success" element={<SignUpSuccess />} />
-              <Route path="signin" element={<SignIn />} />
-              <Route path="signin/v2" element={<SignInV2 />} />
-              <Route path="signin/find/:id" element={<FindBar />} />
-              {/* <Route path="list" element={<List />} /> */}
-              <Route path="list" element={<PostGallery />} />
-              <Route path="list/detail/:id" element={<Detail />} />
-              <Route path="list/view/:id" element={<PostView />} />
-              <Route path="list/review/:id" element={<ReviewWrite />} />
-              <Route
-                path="purchase/:id"
-                element={<ProtectedRoute element={<Purchase />} />}
-              />
-              <Route element={<MarginLayout />}>
-                <Route path="policy/:id" element={<PolicyBar />} />
+      <Routes location={state?.background ?? location}>
+        <Route path="/" element={<DefaultLayout />}>
+          <Route path="admin/scriptManage" element={<AdminSwitch page={0} />} />
+          <Route path="admin/orderManage" element={<AdminSwitch page={1} />} />
 
-                <Route
-                  path="purchase/success"
-                  element={<ProtectedRoute element={<PurchaseSuccess />} />}
-                />
-                <Route
-                  path="purchase/abort"
-                  element={<ProtectedRoute element={<Abort />} />}
-                />
-                <Route path="post" element={<PostWork />} />
+          <Route index element={<MainVer2 />} />
+          <Route path="v1" element={<MainVer1 />} />
 
-                <Route
-                  path="mypage/liked"
-                  element={<ProtectedRoute element={<LikedWorks />} />}
-                />
+          <Route path="signup" element={<SignUpDefault />} />
+          <Route path="signup/success" element={<SignUpSuccess />} />
+          <Route path="signin" element={<SignIn />} />
+          <Route path="signin/v2" element={<SignInV2 />} />
+          <Route path="signin/find/:id" element={<FindBar />} />
 
-                <Route
-                  path="mypage/purchased"
-                  element={<ProtectedRoute element={<PurchasedScript />} />}
-                />
-                <Route
-                  path="mypage/purchased/performance-info/:id"
-                  element={<ProtectedRoute element={<PerformanceInfo />} />}
-                />
-                <Route
-                  path="mypage/purchased/performance-refund/:id"
-                  element={<ProtectedRoute element={<PerformanceRefund />} />}
-                />
-                <Route
-                  path="mypage/scriptmanage"
-                  element={<ProtectedRoute element={<ScriptManage />} />}
-                />
-                <Route
-                  path="mypage/scriptmanage/detail/:scriptId"
-                  element={<ProtectedRoute element={<ScriptManageDetail />} />}
-                />
-                <Route
-                  path="mypage/scriptmanage/askedperform/:id"
-                  element={<AskedPerformManage />}
-                />
-                <Route
-                  path="mypage/infochange"
-                  element={<ProtectedRoute element={<AccountInfoChange />} />}
-                />
+          {/* <Route path="list" element={<List />} /> */}
+          <Route path="list" element={<PostGallery />} />
 
-                <Route path="*" element={<NotFound />} />
+          <Route path="list/detail/:id" element={<Detail />} />
+          <Route path="list/view/:id" element={<PostView />} />
+          <Route path="list/review/:id" element={<ReviewWrite />} />
+          <Route
+            path="purchase/:id"
+            element={<ProtectedRoute element={<Purchase />} />}
+          />
 
-                {/* 테스트용 routing */}
-                <Route path="test/loading" element={<Loading />} />
-                <Route path="test/404" element={<NotFound />} />
-                <Route path="test/signup" element={<SignUpDefault />} />
-                <Route path="test/delete" element={<AccountInfoChange />} />
-              </Route>
-            </Route>
-          </Routes>
-        </AuthProvider>
-      </BrowserRouter>
+          <Route element={<MarginLayout />}>
+            <Route path="policy/:id" element={<PolicyBar />} />
+
+            <Route
+              path="purchase/success"
+              element={<ProtectedRoute element={<PurchaseSuccess />} />}
+            />
+            <Route
+              path="purchase/abort"
+              element={<ProtectedRoute element={<Abort />} />}
+            />
+            <Route path="post" element={<PostWork />} />
+
+            <Route
+              path="mypage/liked"
+              element={<ProtectedRoute element={<LikedWorks />} />}
+            />
+
+            <Route
+              path="mypage/purchased"
+              element={<ProtectedRoute element={<PurchasedScript />} />}
+            />
+            <Route
+              path="mypage/purchased/performance-info/:id"
+              element={<ProtectedRoute element={<PerformanceInfo />} />}
+            />
+            <Route
+              path="mypage/purchased/performance-refund/:id"
+              element={<ProtectedRoute element={<PerformanceRefund />} />}
+            />
+            <Route
+              path="mypage/scriptmanage"
+              element={<ProtectedRoute element={<ScriptManage />} />}
+            />
+            <Route
+              path="mypage/scriptmanage/detail/:scriptId"
+              element={<ProtectedRoute element={<ScriptManageDetail />} />}
+            />
+            <Route
+              path="mypage/scriptmanage/askedperform/:id"
+              element={<AskedPerformManage />}
+            />
+            <Route
+              path="mypage/infochange"
+              element={<ProtectedRoute element={<AccountInfoChange />} />}
+            />
+
+            <Route path="*" element={<NotFound />} />
+
+            {/* 테스트용 routing */}
+            <Route path="test/loading" element={<Loading />} />
+            <Route path="test/404" element={<NotFound />} />
+            <Route path="test/signup" element={<SignUpDefault />} />
+            <Route path="test/delete" element={<AccountInfoChange />} />
+          </Route>
+        </Route>
+      </Routes>
+
+      {state?.background && (
+        <Routes>
+          <Route path="/signin" element={<SignInDialog />} />
+        </Routes>
+      )}
     </div>
   );
 }

--- a/src/components/auth/SignInDialog.scss
+++ b/src/components/auth/SignInDialog.scss
@@ -1,0 +1,43 @@
+@use "./../../styles/_responsive.scss" as r;
+
+.signin-dialog {
+  width: 414px;
+  @include r.media-mobile {
+    width: 390px;
+  }
+  @include r.media-small-mobile {
+    width: 240px;
+  }
+}
+
+.signin-dialog .title {
+  margin-top: 40px;
+  margin-bottom: 30px;
+}
+
+.signin-dialog .content-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+
+  width: 100%;
+
+  @include r.media-small-mobile {
+    gap: 15px;
+  }
+}
+
+.signin-dialog .extra-link {
+  display: flex;
+  justify-content: center;
+  gap: 19px;
+
+  margin-top: 37.5px;
+  margin-bottom: 41.5px;
+}
+
+.signin-dialog .extra-link img {
+  @include r.media-small-mobile {
+    height: 14px;
+  }
+}

--- a/src/components/auth/SignInDialog.tsx
+++ b/src/components/auth/SignInDialog.tsx
@@ -1,0 +1,192 @@
+import axios from "axios";
+import clsx from "clsx";
+import { useState, useEffect, useContext } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+import Loading from "../../pages/Loading";
+
+import { BottomBtn } from ".";
+import { AuthInputField, AuthPwInputField } from "../inputField";
+
+import useWindowDimensions from "@/hooks/useWindowDimensions";
+
+import AuthContext from "../../contexts/AuthContext";
+
+import { SERVER_URL } from "../../constants/ServerURL.js";
+
+import bar from "../../assets/image/auth/bar.svg";
+
+import "./SignInDialog.scss";
+import "./../../styles/utilities.css";
+import { Dialog } from "@mui/material";
+
+function SignInDialog() {
+  const { login } = useContext(AuthContext);
+  const [id, setId] = useState("");
+  const [pw, setPw] = useState("");
+
+  const [showErrorMsg, setShowErrorMsg] = useState(false);
+  const [isIdPwMatch, setIsIdPwMatch] = useState(true);
+
+  const [idPwNull, setIdPwNull] = useState(true);
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const { isMobile, isSmallMobile } = useWindowDimensions().widthConditions;
+
+  const from = location.state?.from?.pathname || "/"; // 이전 페이지로 이동
+
+  useEffect(() => {
+    setShowErrorMsg(false);
+    if (id === "" || pw === "") {
+      setIdPwNull(true);
+    } else {
+      setIdPwNull(false);
+    }
+  }, [id, pw]);
+
+  const onClickConfirmButton = async () => {
+    // initialize
+    setIsLoading(true);
+    setIsIdPwMatch(false);
+
+    try {
+      const { data } = await axios.post(`${SERVER_URL}auth/signin`, {
+        userId: id,
+        password: pw,
+      });
+
+      if (data.accessToken && data.refreshToken) {
+        // accessToken을 쿠키에 저장 -> context 호출
+        login(data.accessToken, data.refreshToken, data.nickname);
+
+        setIsIdPwMatch(true);
+        // 이전 페이지로 이동 (중복 네비게이션 제거)
+        navigate(from, { replace: true });
+      } else {
+        setIsIdPwMatch(false);
+      }
+    } catch (error) {
+      // AxiosError 안전 처리
+      // @ts-ignore - 런타임 안전을 위해 옵셔널 체이닝 사용
+      if (error?.response?.data?.error === "signin error") {
+        alert("로그인 오류, 다시 시도해 주세요.");
+      }
+      setIsIdPwMatch(false);
+    }
+    setShowErrorMsg(true);
+    setIsLoading(false);
+  };
+
+  const handleClose = () => {
+    navigate(-1);
+  };
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  return (
+    <Dialog
+      open
+      onClose={handleClose}
+      keepMounted
+      slotProps={{
+        paper: {
+          sx: {
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            margin: 0,
+            width: isMobile ? "450px" : isSmallMobile ? "280px" : "500px",
+            borderRadius: "30px",
+          },
+        },
+      }}
+    >
+      <form className="signin-dialog" onSubmit={onClickConfirmButton}>
+        <div
+          className={clsx(
+            "title t-center",
+            !isSmallMobile ? "h2-medium" : "h5-medium"
+          )}
+        >
+          로그인
+        </div>
+        <div className="content-wrap">
+          <AuthInputField
+            type="text"
+            placeholder="아이디를 입력해주세요."
+            value={id}
+            onChange={(event) => {
+              setId(event.target.value);
+            }}
+            fontMode={isSmallMobile ? "12" : "default"}
+            style={{
+              width: "100%",
+              ...(isSmallMobile ? { height: "48px" } : {}),
+            }}
+          />
+          <AuthPwInputField
+            placeholder="비밀번호를 입력해주세요."
+            value={pw}
+            onChange={(event) => {
+              setPw(event.target.value);
+            }}
+            fontMode={isSmallMobile ? "12" : "default"}
+            style={{
+              width: "100%",
+              ...(isSmallMobile ? { height: "48px" } : {}),
+            }}
+            errorFlag={showErrorMsg && !isIdPwMatch}
+            errorMessage="아이디 혹은 비밀번호가 일치하지 않습니다."
+          />
+        </div>
+
+        <div className="h-[32px]"></div>
+
+        <div className="w-full">
+          <BottomBtn
+            type="submit"
+            disabled={idPwNull}
+            style={{ width: "100%" }}
+          >
+            로그인
+          </BottomBtn>
+        </div>
+        <div className="extra-link">
+          <div className="flex">
+            <p
+              className={clsx(
+                "c-pointer",
+                !isSmallMobile ? "p-small-regular" : "p-xs-regular"
+              )}
+              onClick={() => {
+                navigate("/signin/find/0");
+              }}
+            >
+              아이디/비밀번호 찾기
+            </p>
+          </div>
+          <img className="cursor-default" src={bar} alt="|" />
+          <p
+            className={clsx(
+              "c-pointer",
+              !isSmallMobile ? "p-small-regular" : "p-xs-regular"
+            )}
+            onClick={() => {
+              navigate("/signup");
+            }}
+          >
+            회원가입
+          </p>
+        </div>
+      </form>
+    </Dialog>
+  );
+}
+
+export default SignInDialog;

--- a/src/components/navBar/SideMenuDialog.tsx
+++ b/src/components/navBar/SideMenuDialog.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
 import Dialog from "@mui/material/Dialog";
 import Slide from "@mui/material/Slide";
 import { TransitionProps } from "@mui/material/transitions";
@@ -38,10 +39,16 @@ const SideMenuDialog: React.FC<SideMenuDialogProps> = ({ open, onClose }) => {
   const { width } = useWindowDimensions();
 
   /** navigateWithRefresh 이후 창 닫기 */
-  const navigate = (event: React.MouseEvent, path: string) => {
+  const navigateWithRefreshAndClose = (
+    event: React.MouseEvent,
+    path: string
+  ) => {
     navigateWithRefresh(event, path);
     onClose();
   };
+
+  const navigate = useNavigate();
+  const location = useLocation();
 
   return (
     <Dialog
@@ -77,7 +84,7 @@ const SideMenuDialog: React.FC<SideMenuDialogProps> = ({ open, onClose }) => {
           <div
             className="navbar_logo a-items-center"
             onClick={(event) => {
-              navigate(event, "/");
+              navigateWithRefreshAndClose(event, "/");
             }}
           >
             <img className="icon w-[23px]" src={navLogo} alt="logo" />
@@ -102,7 +109,7 @@ const SideMenuDialog: React.FC<SideMenuDialogProps> = ({ open, onClose }) => {
         )}
         <SideDialogBtn
           onClick={(event: React.MouseEvent) => {
-            navigate(event, "/list");
+            navigateWithRefreshAndClose(event, "/list");
           }}
         >
           작품 둘러보기
@@ -110,7 +117,7 @@ const SideMenuDialog: React.FC<SideMenuDialogProps> = ({ open, onClose }) => {
         <div className="div-inside" />
         <SideDialogBtn
           onClick={(event: React.MouseEvent) => {
-            navigate(event, "/post");
+            navigateWithRefreshAndClose(event, "/post");
           }}
         >
           작품 등록하기
@@ -127,7 +134,7 @@ const SideMenuDialog: React.FC<SideMenuDialogProps> = ({ open, onClose }) => {
             </div>
             <SideDialogBtn
               onClick={(event: React.MouseEvent) => {
-                navigate(event, "/mypage/liked");
+                navigateWithRefreshAndClose(event, "/mypage/liked");
               }}
             >
               좋아한 작품
@@ -135,7 +142,7 @@ const SideMenuDialog: React.FC<SideMenuDialogProps> = ({ open, onClose }) => {
             <div className="div-inside" />
             <SideDialogBtn
               onClick={(event: React.MouseEvent) => {
-                navigate(event, "/mypage/purchased");
+                navigateWithRefreshAndClose(event, "/mypage/purchased");
               }}
             >
               구매한 작품
@@ -143,7 +150,7 @@ const SideMenuDialog: React.FC<SideMenuDialogProps> = ({ open, onClose }) => {
             <div className="div-inside" />
             <SideDialogBtn
               onClick={(event: React.MouseEvent) => {
-                navigate(event, "/mypage/scriptmanage");
+                navigateWithRefreshAndClose(event, "/mypage/scriptmanage");
               }}
             >
               작품 관리
@@ -165,7 +172,7 @@ const SideMenuDialog: React.FC<SideMenuDialogProps> = ({ open, onClose }) => {
           <>
             <SideDialogBtn
               onClick={(event: React.MouseEvent) => {
-                navigate(event, "/mypage/infochange");
+                navigateWithRefreshAndClose(event, "/mypage/infochange");
               }}
             >
               회원 정보 수정
@@ -174,7 +181,7 @@ const SideMenuDialog: React.FC<SideMenuDialogProps> = ({ open, onClose }) => {
             <SideDialogBtn
               onClick={(event: React.MouseEvent) => {
                 logout();
-                navigate(event, "/");
+                navigateWithRefreshAndClose(event, "/");
               }}
             >
               로그아웃
@@ -184,8 +191,20 @@ const SideMenuDialog: React.FC<SideMenuDialogProps> = ({ open, onClose }) => {
         ) : (
           <>
             <SideDialogBtn
-              onClick={(event: React.MouseEvent) => {
-                navigate(event, "/signin");
+              onClick={() => {
+                navigate("/signin", {
+                  state: {
+                    // Avoid passing full location.state to prevent DataCloneError
+                    background: {
+                      pathname: location.pathname,
+                      search: location.search,
+                      hash: location.hash,
+                      key: location.key,
+                    },
+                    from: location.pathname,
+                  },
+                });
+                onClose();
               }}
             >
               로그인

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,12 +1,18 @@
 import React from "react";
+import { BrowserRouter } from "react-router-dom";
 import ReactDOM from "react-dom/client";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { AuthProvider } from "./contexts/AuthContext";
 import "./index.css";
 import "./styles/tailwind.css";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/pages/MainNav.jsx
+++ b/src/pages/MainNav.jsx
@@ -94,7 +94,18 @@ function MainNav() {
           <div className="navbar_login">
             <RoundBtnV2
               onClick={() => {
-                navigate("/signin", { state: { from: location } });
+                navigate("/signin", {
+                  state: {
+                    // Avoid passing full location.state to prevent DataCloneError
+                    background: {
+                      pathname: location.pathname,
+                      search: location.search,
+                      hash: location.hash,
+                      key: location.key,
+                    },
+                    from: location.pathname,
+                  },
+                });
               }}
               className="signin_btn p-large-regular w-[150px] h-[44px] rounded-[30px]"
               color="white"

--- a/src/routes/ProtectedRoute.js
+++ b/src/routes/ProtectedRoute.js
@@ -17,7 +17,7 @@ const ProtectedRoute = ({ element }) => {
         const newAccessToken = await refreshAccessToken();
         if (!newAccessToken) {
           alert("로그인이 필요한 서비스입니다.");
-          navigate("/signin", { state: { from: location } });
+          navigate("/signin", { state: { from: location.pathname } });
         }
       })();
     }


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요. -->

- #301 

## 📌 PR 내용

<!-- PR 내용을 설명해주세요. -->

- 로그인 페이지 modal 형식으로 변경
- `main.jsx` 및 `app.jsx` 구조 변경

## 🗣️ 팀원에게 공유할 내용

- 뒤에 다른 페이지를 띄워둔 상태로 로그인 화면까지 띄우려면 두 방법이 있었습니다.

  1. 다른 route로 관리하되, 이전 페이지의 location 정보가 넘어올 경우에 이전 페이지 같이 렌더링
  2. 냅다 상태관리 라이브러리 갖다 써서 on/off 관리하기
  
  1번 방식을 택하여, 현재 주소창에 직접 `/signin` 경로를 입력하거나 토큰이 정상적이지 않을 경우 기존 로그인 페이지로, `MainNav.jsx`와 `SideMenuDialog.tsx`에서 버튼을 눌러 이동했을 경우엔 새로 만든 Modal 페이지로 이동하도록 구현했습니다. 자세한 내용은 `main.jsx`와 `app.jsx`의 변경된 부분을 참고해주시면 됩니다.

- 새로 만든 SignInDialog는 기존 SignIn 파일을 복사해오되, 기존 `Box.jsx`, `RectangleForm.jsx` component에 의해 감싸지던 구조를 변경하여 더 직관적으로 refactored된 상태입니다. 
<img width="495" height="171" alt="image" src="https://github.com/user-attachments/assets/fc2d50e1-1def-49d4-a3db-c5a764a04cd4" />
<img width="572" height="369" alt="image" src="https://github.com/user-attachments/assets/8b879c96-3b65-4653-a11d-37b9c6cc1f45" />


## ✅ Check List

- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] 코드 스타일을 eslint/prettier로 맞췄나요?
