### PR TITLE
feat: 어드민 통계 api 연결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@mui/material": "^6.4.4",
         "@tailwindcss/line-clamp": "^0.4.4",
         "@tailwindcss/vite": "^4.1.11",
+        "@tanstack/react-query": "^5.85.3",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -2571,6 +2572,32 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.85.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.85.3.tgz",
+      "integrity": "sha512-9Ne4USX83nHmRuEYs78LW+3lFEEO2hBDHu7mrdIgAFx5Zcrs7ker3n/i8p4kf6OgKExmaDN5oR0efRD7i2J0DQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.85.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.85.3.tgz",
+      "integrity": "sha512-AqU8TvNh5GVIE8I+TUU0noryBRy7gOY0XhSayVXmOPll4UkZeLWKDwi0rtWOZbwLRCbyxorfJ5DIjDqE7GXpcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.85.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@mui/material": "^6.4.4",
     "@tailwindcss/line-clamp": "^0.4.4",
     "@tailwindcss/vite": "^4.1.11",
+    "@tanstack/react-query": "^5.85.3",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/api/admin/statisticApi.ts
+++ b/src/api/admin/statisticApi.ts
@@ -1,0 +1,39 @@
+import axios from "axios";
+
+import { SERVER_URL } from "@/constants/ServerURL";
+const api = axios.create({
+  baseURL: SERVER_URL, // Use environment variables
+  timeout: 30000,
+});
+
+export interface GetStatisticsResponse {
+  userCnt: number;
+  scriptCnt: number;
+  viewCnt: number;
+  reviewCnt: number;
+}
+
+export const getStatistics = async (
+  accessToken?: string
+): Promise<GetStatisticsResponse> => {
+  try {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+
+    if (accessToken) {
+      headers["Authorization"] = `Bearer ${accessToken}`;
+    }
+
+    const response = await api.get<GetStatisticsResponse>("/admin/statistics", {
+      headers,
+      withCredentials: true, // 쿠키 인증 시 필요
+    });
+
+    console.log(response.data);
+    return response.data;
+  } catch (error) {
+    console.error("Error getStatistics:", error);
+    throw new Error(`어드민 통계 api 호출 실패 ${(error as Error).message}`);
+  }
+};

--- a/src/components/admin/AdminStatisticManage.tsx
+++ b/src/components/admin/AdminStatisticManage.tsx
@@ -1,13 +1,51 @@
+import Cookies from "js-cookie";
 import StatCard from "@/components/admin/dashBoard/StatCard";
 
+import { GetStatisticsResponse } from "@/api/admin/statisticApi";
+import { useAdminStatistics } from "@/hooks/useAdminStatistics";
 const AdminStatisticManage = () => {
+  const accessToken = Cookies.get("accessToken");
+
+  const { data, isLoading, isError, error, refetch, isFetching } =
+    useAdminStatistics(accessToken);
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-3 gap-x-[21px] gap-y-[20px] mt-[80px] mb-[40px]">
+        <StatCard label="유저" value="—" />
+        <StatCard label="작품" value="—" />
+        <StatCard label="조회수" value="—" />
+        <StatCard label="후기" value="—" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="mt-[80px]">
+        <p className="text-red-600">통계 불러오기 실패: {error.message}</p>
+        <button className="mt-2 underline" onClick={() => refetch()}>
+          다시 시도
+        </button>
+      </div>
+    );
+  }
+
+  const EMPTY: GetStatisticsResponse = {
+    userCnt: 0,
+    scriptCnt: 0,
+    viewCnt: 0,
+    reviewCnt: 0,
+  };
+  const stats = data ?? EMPTY;
+
   return (
     <div className="pb-[1205px]">
-      <div className=" grid grid-cols-3 gap-x-[21px] gap-y-[20px] mt-[80px] mb-[40px]">
-        <StatCard label={"유저"} value={5} />
-        <StatCard label={"작품"} value={5} />
-        <StatCard label={"조회수"} value={5} />
-        <StatCard label={"후기"} value={5} />
+      <div className="grid grid-cols-3 gap-x-[21px] gap-y-[20px] mt-[80px] mb-[40px]">
+        <StatCard label="유저" value={stats.userCnt} />
+        <StatCard label="작품" value={stats.scriptCnt} />
+        <StatCard label="조회수" value={stats.viewCnt} />
+        <StatCard label="후기" value={stats.reviewCnt} />
       </div>
 
       <span className="w-full">

--- a/src/hooks/useAdminStatistics.ts
+++ b/src/hooks/useAdminStatistics.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+import { getStatistics, GetStatisticsResponse } from "@/api/admin/statisticApi";
+
+export const ADMIN_STATISTICS_KEY = ["adminStatistics"] as const;
+
+export function useAdminStatistics(accessToken?: string) {
+  return useQuery<GetStatisticsResponse, Error>({
+    queryKey: ADMIN_STATISTICS_KEY,
+    queryFn: () => getStatistics(accessToken),
+
+    // “페이지 한번 열면 캐싱 + 내가 원할 때만 새로고침” 패턴 
+    staleTime: Infinity,
+    gcTime: Infinity,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  });
+}

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,0 +1,16 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60_000, // 1분 동안 fresh
+      gcTime: 5 * 60_000, // 5분 캐시 보관
+      refetchOnWindowFocus: false, // 포커스시 자동 리패치 X
+      retry(failureCount, err: any) {
+        const status = err?.response?.status;
+        if (status && status >= 400 && status < 500) return false;
+        return failureCount < 1;
+      },
+    },
+  },
+});

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,8 +5,13 @@ import App from "./App";
 import "./index.css";
 import "./styles/tailwind.css";
 
+import { QueryClientProvider } from "@tanstack/react-query";
+import { queryClient } from "./lib/queryClient";
+
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요. -->

- #이슈번호
- #303 

## 📌 PR 내용

<!-- PR 내용을 설명해주세요. -->
- React Query 도입으로 통계 API 연동 완료
- lib/queryClient.ts에 QueryClient 전역 생성 및 기본 옵션 설정
    - staleTime: 1분
    - gcTime: 5분 
    - 창 포커스 시 자동 refetch 비활성화
    - 4xx 응답은 재시도 없음, 그 외 최대 1회 재시도
- main.jsx에서 QueryClientProvider로 App 래핑 → 전역에서 사용 가능
- useAdminStatistics 훅 추가 후 AdminStatisticManage에서 사용하도록 변경
- 통계는 브라우저 새로고침 시 1회 요청 후 캐싱 사용 (수동 새로고침/무효화 시에만 재요청)

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
- React Query 선택 이유
    - 서버 상태를 다룰 때 캐싱/로딩/에러/재시도 로직을 반복 구현할 필요 없이, useQuery 한 가지 패턴으로 통일할 수 있어 유지보수성이 좋습니다.
    - 통계처럼 “한 번 가져오고 필요 시만 갱신”하는 요구에 staleTime, invalidateQueries로 정책을 명확히 설정할 수 있습니다.
    -  이번 적용 범위는 통계 페이지에 한정되어 있어 단순 캐싱 목적만 보면 다소 무거울 수 있으나, 추후 관리자 API 확대 시 동일 패턴으로 확장하기 용이한 것 같고, 연습삼아 적용해 보았습니다.
   
- 통계 캐싱 정책:
    - 기본: 새로고침 1회 호출 → 캐시 사용
    -  - 변경 액션(작품 등록/삭제, 리뷰 작성 등) 이후에 최신화가 필요하면 무효화 호출
 ```ts
// 예시) 변경 뮤테이션 onSuccess에서
import { queryClient } from '@/lib/queryClient';
queryClient.invalidateQueries({ queryKey: ['adminStatistics'] });
 ```
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->

## ✅ Check List

- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
- [ ] 코드 스타일을 eslint/prettier로 맞췄나요?
