### PR TITLE
fix: 마이페이지 디자인 버그 수정

### DIFF
--- a/src/components/myPage/NullScriptContent.tsx
+++ b/src/components/myPage/NullScriptContent.tsx
@@ -52,7 +52,7 @@ const NullScriptContent = ({ currentPage = 0 }: NullScriptContentProps) => {
   return (
     <div
       className={`f-dir-column a-items-center ${
-        currentPage === 2 ? "pt-[16.759vh]" : " pt-[7.879vh]"
+        currentPage === 2 ? "pt-[calc(7.879vh+3.889vh-10px)]" : " pt-[7.879vh]"
       }`}
       id="null-script-content"
     >

--- a/src/components/myPage/ScriptContent.jsx
+++ b/src/components/myPage/ScriptContent.jsx
@@ -110,7 +110,9 @@ const ScriptContent = ({
                 ) : null}
                 {/* 작품 관리 페이지 상단 버튼: 심사 끝났을 경우 표시 */}
                 {currentPage === "1" && script.checked === "PASS" ? (
-                  <ScriptManageTopBtn className="" script={script} />
+                  <div className="translate-y-[-15px]">
+                    <ScriptManageTopBtn className="" script={script} />
+                  </div>
                 ) : null}
               </div>
 


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요. -->

- #317 

## 📌 PR 내용

<!-- PR 내용을 설명해주세요. -->

- [fix: 좋아한 작품 NullScriptContent 글자 위치 수정](https://github.com/Podo-Store/FE/commit/cad3d559f83bbbd263cb1da412eefee086dc441a)
- [fix: 작품 관리 상단 버튼 위치 수정](https://github.com/Podo-Store/FE/commit/9d9d79605e86abf27bd9e347bca372e66b4274d0)

## 🗣️ 팀원에게 공유할 내용

<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->

- `ScriptContent.jsx`에서 `ScriptManageTopBtn`이 다른 위치에도 사용되기 때문에, 위치 조정이 필요한 부분을 wrap해서 디자인을 먹였습니다.
  ```typescript
    <div className="translate-y-[-15px]"> 
      <ScriptManageTopBtn className="" script={script} />
    </div>
  ``` 

## ✅ Check List

- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
- [ ] 코드 스타일을 eslint/prettier로 맞췄나요?
