### PR TITLE
feat: 작품 관리 페이지 심사 취소 기능 추가

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,0 +1,7 @@
+import axios from "axios";
+import { SERVER_URL } from "@/constants/ServerURL";
+
+export const api = axios.create({
+  baseURL: SERVER_URL,
+  timeout: 30000,
+});

--- a/src/api/user/profile/cancelPostApi.ts
+++ b/src/api/user/profile/cancelPostApi.ts
@@ -1,0 +1,31 @@
+import { AxiosError } from "axios";
+import { api } from "@/api/api";
+
+/**
+ * 심사 취소
+ * DELETE /profile/work/cancel/{id}
+ */
+export const cancelReview = async (
+  id: string,
+  accessToken: string
+): Promise<boolean> => {
+  try {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "multipart/form-data",
+    };
+
+    const formData = new FormData();
+    formData.append("id", id);
+
+    const { data } = await api.delete(`profile/work/cancel/${id}`, {
+      headers,
+      data: formData,
+    });
+
+    return data === true;
+  } catch (error) {
+    const err = error as AxiosError<{ error: string }>;
+    throw new Error(err.response?.data?.error ?? "심사 취소에 실패했습니다.");
+  }
+};

--- a/src/components/myPage/ScriptContent.jsx
+++ b/src/components/myPage/ScriptContent.jsx
@@ -15,6 +15,7 @@ import "./ScriptContent.scss";
 import "./../../styles/utilities.css";
 import { useNavigate } from "react-router-dom";
 import clsx from "clsx";
+import ScriptManageEachTopBtn from "./ScriptManageEachTopBtn.js";
 
 /**
  * 구매한 작품 페이지, 작품 관리 페이지의 상품 란,
@@ -72,9 +73,7 @@ const ScriptContent = ({
             <div className=" script-tag">
               <div
                 className={`a-items-center ${
-                  currentPage === "1" && script.checked === "PASS"
-                    ? "j-content-between"
-                    : ""
+                  currentPage === "1" ? "j-content-between" : ""
                 }`}
                 id="title"
               >
@@ -109,11 +108,17 @@ const ScriptContent = ({
                   <ScriptContentPopup onClose={() => setShowPopup(false)} />
                 ) : null}
                 {/* 작품 관리 페이지 상단 버튼: 심사 끝났을 경우 표시 */}
-                {currentPage === "1" && script.checked === "PASS" ? (
+                {currentPage === "1" && script.checked === "PASS" && (
                   <div className="translate-y-[-15px]">
                     <ScriptManageTopBtn className="" script={script} />
                   </div>
-                ) : null}
+                )}
+                {/* 작품 관리 페이지에서 심사 중일 경우 */}
+                {currentPage === "1" && script.checked === "WAIT" && (
+                  <div className="hidden md:block translate-y-[-15px]">
+                    <ScriptManageEachTopBtn>심사 중</ScriptManageEachTopBtn>
+                  </div>
+                )}
               </div>
 
               <hr className="border border-solid border-[#9E9E9E]"></hr>
@@ -166,6 +171,10 @@ const ScriptContent = ({
               script.checked === "PASS" ? (
                 <div className="relative">
                   <ScriptManageTopBtn className="mobile" script={script} />
+                </div>
+              ) : currentPage === "1" && script.checked === "WAIT" ? (
+                <div className="translate-y-[-43.4px]">
+                  <ScriptManageEachTopBtn>심사 중</ScriptManageEachTopBtn>
                 </div>
               ) : null}
             </div>

--- a/src/components/myPage/ScriptManageBtn.jsx
+++ b/src/components/myPage/ScriptManageBtn.jsx
@@ -1,10 +1,14 @@
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import clsx from "clsx";
+import Cookies from "js-cookie";
 
-import Button from "../button/RoundBtn_149_48";
-
-import "./ScriptManageBtn.scss";
+import { cancelReview } from "@/api/user/profile/cancelPostApi";
 import useWindowDimensions from "@/hooks/useWindowDimensions";
+
+import ScriptManageCancelPopup from "./ScriptManageCancelPopup";
+import Button from "../button/RoundBtn_149_48";
+import "./ScriptManageBtn.scss";
 
 const ReviewCompleted = {
   REVIEW_COMPLETED: "PASS",
@@ -14,6 +18,11 @@ const ReviewCompleted = {
 const ScriptManageBtn = ({ reviewCompleted, id, performSale, style }) => {
   const navigate = useNavigate();
   const { isSmallMobile } = useWindowDimensions().widthConditions;
+
+  const accessToken = Cookies.get("accessToken");
+
+  // 심사 취소 팝업
+  const [open, setOpen] = useState(false);
 
   return (
     <div className="script-manage-btn">
@@ -57,9 +66,15 @@ const ScriptManageBtn = ({ reviewCompleted, id, performSale, style }) => {
           [ReviewCompleted.UNDER_REVIEWING]: (
             <div className="script-manage-flex">
               <div> </div>
-              <Button disabled={true} style={style}>
-                심사 중
+              <Button
+                style={style}
+                onClick={() => {
+                  setOpen(true);
+                }}
+              >
+                심사 취소
               </Button>
+              <ScriptManageCancelPopup open={open} setOpen={setOpen} id={id} />
             </div>
           ),
         }[reviewCompleted]

--- a/src/components/myPage/ScriptManageCancelPopup.tsx
+++ b/src/components/myPage/ScriptManageCancelPopup.tsx
@@ -2,6 +2,7 @@ import { Dialog } from "@mui/material";
 import { cancelReview } from "@/api/user/profile/cancelPostApi";
 import RoundBtn_135_40 from "../button/RoundBtn_135_40";
 import Cookies from "js-cookie";
+import useWindowDimensions from "@/hooks/useWindowDimensions";
 
 interface ScriptManageCancelPopupProps {
   open: boolean;
@@ -14,6 +15,7 @@ const ScriptManageCancelPopup = ({
   setOpen,
   id,
 }: ScriptManageCancelPopupProps) => {
+  const { isSmallMobile } = useWindowDimensions().widthConditions;
   const accessToken = Cookies.get("accessToken")!;
   return (
     <Dialog
@@ -30,11 +32,16 @@ const ScriptManageCancelPopup = ({
         <div className="flex flex-col gap-[10px] text-center">
           <p className="p-medium-bold">심사를 정말 취소할까요?</p>
           <p className="p-medium-bold">
-            심사를 취소하게 되면 즉시 심사가 중지됩니다.
+            심사를 취소하게 되면 즉시 심사가 {isSmallMobile && <br />}
+            중지됩니다.
           </p>
         </div>
         <div className="flex gap-[15px]">
-          <RoundBtn_135_40 color="grey" onClick={() => setOpen(false)}>
+          <RoundBtn_135_40
+            color="grey"
+            onClick={() => setOpen(false)}
+            style={isSmallMobile ? { width: "119px" } : {}}
+          >
             유지하기
           </RoundBtn_135_40>
           <RoundBtn_135_40
@@ -50,6 +57,7 @@ const ScriptManageCancelPopup = ({
                 alert("심사 취소 중 오류가 발생했습니다.");
               }
             }}
+            style={isSmallMobile ? { width: "119px" } : {}}
           >
             심사 취소하기
           </RoundBtn_135_40>

--- a/src/components/myPage/ScriptManageCancelPopup.tsx
+++ b/src/components/myPage/ScriptManageCancelPopup.tsx
@@ -1,0 +1,62 @@
+import { Dialog } from "@mui/material";
+import { cancelReview } from "@/api/user/profile/cancelPostApi";
+import RoundBtn_135_40 from "../button/RoundBtn_135_40";
+import Cookies from "js-cookie";
+
+interface ScriptManageCancelPopupProps {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  id: string;
+}
+
+const ScriptManageCancelPopup = ({
+  open,
+  setOpen,
+  id,
+}: ScriptManageCancelPopupProps) => {
+  const accessToken = Cookies.get("accessToken")!;
+  return (
+    <Dialog
+      open={open}
+      onClose={() => setOpen(false)}
+      sx={{
+        "& .MuiDialog-paper": {
+          borderRadius: "20px",
+          boxShadow: "0 0 20px 0 rgba(0, 0, 0, 0.25)",
+        },
+      }}
+    >
+      <section className="flex flex-col justify-between items-center pt-[42px] pb-[30px] w-[280px] sm:w-[350px] h-[235px]">
+        <div className="flex flex-col gap-[10px] text-center">
+          <p className="p-medium-bold">심사를 정말 취소할까요?</p>
+          <p className="p-medium-bold">
+            심사를 취소하게 되면 즉시 심사가 중지됩니다.
+          </p>
+        </div>
+        <div className="flex gap-[15px]">
+          <RoundBtn_135_40 color="grey" onClick={() => setOpen(false)}>
+            유지하기
+          </RoundBtn_135_40>
+          <RoundBtn_135_40
+            color="purple"
+            onClick={async () => {
+              try {
+                await cancelReview(id, accessToken);
+
+                alert("심사 취소가 완료되었습니다.");
+                window.location.reload();
+              } catch (error) {
+                console.error("심사 취소 중 오류 발생:", error);
+                alert("심사 취소 중 오류가 발생했습니다.");
+              }
+            }}
+          >
+            심사 취소하기
+          </RoundBtn_135_40>
+        </div>
+      </section>
+    </Dialog>
+  );
+};
+
+export default ScriptManageCancelPopup;


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요. -->

- #324 

## 📌 PR 내용

<!-- PR 내용을 설명해주세요. -->

- api.ts 추가
- 작품 관리 페이지 심사 취소 UI 적용 및 API 연결

## 🗣️ 팀원에게 공유할 내용

<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->

- 범용적으로 쓸만한 api.ts 추가했습니다.
- 기본적으로 `ScriptContent.jsx`에서는 버튼이 두 개이므로 버튼 두개와 기타 스타일을 합친 `ScriptManageTopBtn.jsx`를 사용하지만, 심사 중일 때는 하나만 보여야 하므로 단일 버튼 component `ScriptManageEachTopBtn.tsx`를 활용합니다. 
- 어딘가에는 Popup을 위치시켜야 하는데, 굳이 여기서만 쓰이는 state 하나를 관리하기 위해 상태 정보를 저장하는 건 아닌 것 같아 `ScriptManageBtn.jsx`에 popup component가 종속적이게 되었습니다.

## ✅ Check List

- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
- [ ] 코드 스타일을 eslint/prettier로 맞췄나요?
