### PR TITLE
feat: 랜딩페이지 공연된 작품 interaction 추가, PostManageDetail 로딩 modal 추가 외 기타 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .env
+
+ServerURL.js

--- a/src/components/detail/preview/Modal.jsx
+++ b/src/components/detail/preview/Modal.jsx
@@ -63,8 +63,8 @@ const Modal = ({
           top: "50%",
           transform: "translateY(-50%)",
           color: "white",
-          "&.Mui-disabled": { opacity: 0.5 },
           zIndex: 10,
+          "&.Mui-disabled": { opacity: 0 },
         }}
       >
         <img src={inequalityLeft} alt="prev" />
@@ -102,8 +102,8 @@ const Modal = ({
           top: "50%",
           transform: "translateY(-50%)",
           color: "white",
-          "&.Mui-disabled": { opacity: 0.5 },
           zIndex: 10,
+          "&.Mui-disabled": { opacity: 0 },
         }}
       >
         <img src={inequalityRight} alt="next" />

--- a/src/components/landing/Page2_5Content.tsx
+++ b/src/components/landing/Page2_5Content.tsx
@@ -1,6 +1,6 @@
 import { MOCK_SHOWS } from "@/constants/ShowCard";
 
-const Page3_5Content = () => {
+const Page2_5Content = () => {
   return MOCK_SHOWS.map((show) => (
     <div
       key={show.id}
@@ -34,4 +34,4 @@ const Page3_5Content = () => {
   ));
 };
 
-export default Page3_5Content;
+export default Page2_5Content;

--- a/src/components/landing/Page3_5Content.tsx
+++ b/src/components/landing/Page3_5Content.tsx
@@ -2,19 +2,32 @@ import { MOCK_SHOWS } from "@/constants/ShowCard";
 
 const Page3_5Content = () => {
   return MOCK_SHOWS.map((show) => (
-    <div key={show.id}>
+    <div
+      key={show.id}
+      className="w-[120px] sm:w-[195px] md:w-[260px] lg:w-[286px]"
+    >
       <div
-        className="w-[286px] h-[389px] rounded-[20px] bg-[#D9D9D9] bg-cover bg-center"
+        className="h-[160px] sm:h-[260px] md:h-[347px] lg:h-[389px] rounded-[20px] bg-[#D9D9D9] bg-cover bg-center"
         style={{ backgroundImage: `url(${show.image})` }}
       ></div>
-      <div className="flex flex-col gap-[15px]">
-        <div className="flex flex-col gap-[5px] mt-[5px]">
-          <h4 className="h4-bold">{show.title}</h4>
-          <h5 className="h5-bold">{show.author}</h5>
+
+      <div className="flex flex-col gap-[8px] sm:gap-[10px] md:gap-[15px] mt-[8px] w-full">
+        <div className="flex flex-col gap-[3px] sm:gap-[5px] w-full">
+          <h4 className="p-small-bold sm:p-large-bold md:h4-bold truncate">
+            {show.title}
+          </h4>
+          <h5 className="p-12-bold sm:p-medium-bold md:h5-bold truncate">
+            {show.author}
+          </h5>
         </div>
-        <div className="flex flex-col gap-[5px]">
-          <h5 className="h5-regular">{show.troupe}</h5>
-          <h5 className="h5-regular">{show.period}</h5>
+
+        <div className="flex flex-col gap-[3px] sm:gap-[5px] w-full">
+          <h5 className="p-xs-regular sm:p-medium-regular md:h5-regular truncate">
+            {show.troupe}
+          </h5>
+          <h5 className="p-xs-regular sm:p-medium-regular md:h5-regular truncate">
+            {show.period}
+          </h5>
         </div>
       </div>
     </div>

--- a/src/components/landing/Page3_5Content.tsx
+++ b/src/components/landing/Page3_5Content.tsx
@@ -1,0 +1,24 @@
+import { MOCK_SHOWS } from "@/constants/ShowCard";
+
+const Page3_5Content = () => {
+  return MOCK_SHOWS.map((show) => (
+    <div key={show.id}>
+      <div
+        className="w-[286px] h-[389px] rounded-[20px] bg-[#D9D9D9] bg-cover bg-center"
+        style={{ backgroundImage: `url(${show.image})` }}
+      ></div>
+      <div className="flex flex-col gap-[15px]">
+        <div className="flex flex-col gap-[5px] mt-[5px]">
+          <h4 className="h4-bold">{show.title}</h4>
+          <h5 className="h5-bold">{show.author}</h5>
+        </div>
+        <div className="flex flex-col gap-[5px]">
+          <h5 className="h5-regular">{show.troupe}</h5>
+          <h5 className="h5-regular">{show.period}</h5>
+        </div>
+      </div>
+    </div>
+  ));
+};
+
+export default Page3_5Content;

--- a/src/constants/ServerURL.js
+++ b/src/constants/ServerURL.js
@@ -1,3 +1,0 @@
-// export const SERVER_URL = "http://localhost:8081/";
-// export const SERVER_URL = "http://13.125.61.13:8080/";
-export const SERVER_URL = "https://api.podo-store.com/";

--- a/src/pages/MainVer2.scss
+++ b/src/pages/MainVer2.scss
@@ -201,7 +201,7 @@
 .main-ver2 .page-size {
   position: relative;
   width: 100%;
-  height: 100vh;  /* fallback */
+  height: 100vh; /* fallback */
   height: 100svh; /* iOS Safari safe visual viewport */
   height: 100dvh; /* Dynamic viewport */
   @include r.media-tablet {
@@ -252,8 +252,22 @@
   z-index: -100;
 }
 
+@keyframes slider-left {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-50%);
+  }
+}
+
+.animate-slider-left {
+  animation: slider-left 15s linear infinite;
+  will-change: transform;
+}
+
 .main-ver2 .page4 {
-  height: 100vh;  /* fallback */
+  height: 100vh; /* fallback */
   height: 100svh; /* iOS Safari safe visual viewport */
   height: 100dvh; /* Dynamic viewport */
   @include r.media-tablet {

--- a/src/pages/MainVer2.tsx
+++ b/src/pages/MainVer2.tsx
@@ -288,10 +288,8 @@ const MainVer2 = () => {
           </div>
         </div>
 
-        <Page3 />
-
-        {/* Page 3.5. 공연된 작품 */}
-        <section className="pt-[97px] pb-[116px] w-full bg-[#F5F0FF]">
+        {/* Page 2.5. 공연된 작품 */}
+        <section className="pt-[97px] pb-[116px] w-full">
           <h1 className="title_64px mb-[78px]">
             포도상점의 작품이 공연되었어요
           </h1>
@@ -299,13 +297,13 @@ const MainVer2 = () => {
           <section className="relative w-full overflow-hidden group">
             <div className="animate-slider-left inline-flex group-hover:[animation-play-state:paused]">
               {/* 1번 트랙*/}
-              <div className="inline-flex gap-[100px] px-[50px] shrink-0 w-fit">
+              <div className="inline-flex gap-[20px] md:gap-[45px] lg:gap-[100px] px-[10px] md:px-[22.5px] lg:px-[50px] shrink-0 w-fit">
                 <Page3_5Content />
               </div>
 
               {/* 2번 트랙 */}
               <div
-                className="inline-flex gap-[100px] px-[50px] shrink-0 w-fit"
+                className="inline-flex gap-[20px] md:gap-[45px] lg:gap-[100px] px-[10px] md:px-[22.5px] lg:px-[50px] shrink-0 w-fit"
                 aria-hidden="true"
               >
                 <Page3_5Content />
@@ -313,6 +311,8 @@ const MainVer2 = () => {
             </div>
           </section>
         </section>
+
+        <Page3 />
 
         <div className=" page4 page-size">
           <div className=" page4-size">

--- a/src/pages/MainVer2.tsx
+++ b/src/pages/MainVer2.tsx
@@ -288,8 +288,8 @@ const MainVer2 = () => {
         </div>
 
         {/* Page 2.5. 공연된 작품 */}
-        <section className="pt-[97px] pb-[116px] w-full">
-          <h1 className="title_64px mb-[78px]">
+        <section className="py-[80px] sm:py-[135px] md:py-[150px] lg:py-[271px] w-full">
+          <h1 className="title_64px mb-[30px] sm:mb-[78px]">
             포도상점의 작품이 공연되었어요
           </h1>
 

--- a/src/pages/MainVer2.tsx
+++ b/src/pages/MainVer2.tsx
@@ -34,8 +34,7 @@ import brunch from "../assets/image/landing/page4/brunch.svg";
 import "./MainVer2.scss";
 import "./MainVer2Page2.scss";
 import clsx from "clsx";
-import { MOCK_SHOWS } from "@/constants/ShowCard";
-import Page3_5Content from "@/components/landing/Page3_5Content";
+import Page2_5Content from "@/components/landing/Page2_5Content";
 
 const MainVer2 = () => {
   const [signUpToast, setSignUpToast] = useState<string>("");
@@ -298,7 +297,7 @@ const MainVer2 = () => {
             <div className="animate-slider-left inline-flex group-hover:[animation-play-state:paused]">
               {/* 1번 트랙*/}
               <div className="inline-flex gap-[20px] md:gap-[45px] lg:gap-[100px] px-[10px] md:px-[22.5px] lg:px-[50px] shrink-0 w-fit">
-                <Page3_5Content />
+                <Page2_5Content />
               </div>
 
               {/* 2번 트랙 */}
@@ -306,7 +305,7 @@ const MainVer2 = () => {
                 className="inline-flex gap-[20px] md:gap-[45px] lg:gap-[100px] px-[10px] md:px-[22.5px] lg:px-[50px] shrink-0 w-fit"
                 aria-hidden="true"
               >
-                <Page3_5Content />
+                <Page2_5Content />
               </div>
             </div>
           </section>

--- a/src/pages/MainVer2.tsx
+++ b/src/pages/MainVer2.tsx
@@ -35,6 +35,7 @@ import "./MainVer2.scss";
 import "./MainVer2Page2.scss";
 import clsx from "clsx";
 import { MOCK_SHOWS } from "@/constants/ShowCard";
+import Page3_5Content from "@/components/landing/Page3_5Content";
 
 const MainVer2 = () => {
   const [signUpToast, setSignUpToast] = useState<string>("");
@@ -299,24 +300,7 @@ const MainVer2 = () => {
             <div className="animate-slider-left inline-flex group-hover:[animation-play-state:paused]">
               {/* 1번 트랙*/}
               <div className="inline-flex gap-[100px] px-[50px] shrink-0 w-fit">
-                {MOCK_SHOWS.map((show) => (
-                  <div key={show.id}>
-                    <div
-                      className="w-[400px] h-[534px] rounded-[20px] bg-[#D9D9D9] bg-cover bg-center"
-                      style={{ backgroundImage: `url(${show.image})` }}
-                    ></div>
-                    <div className="flex flex-col gap-[20px]">
-                      <div className="flex flex-col gap-[10px] mt-[10px]">
-                        <h1 className="h1-bold">{show.title}</h1>
-                        <h2 className="h2-bold">{show.author}</h2>
-                      </div>
-                      <div className="flex flex-col gap-[10px]">
-                        <h2 className="h2-regular">{show.troupe}</h2>
-                        <h2 className="h2-regular">{show.period}</h2>
-                      </div>
-                    </div>
-                  </div>
-                ))}
+                <Page3_5Content />
               </div>
 
               {/* 2번 트랙 */}
@@ -324,24 +308,7 @@ const MainVer2 = () => {
                 className="inline-flex gap-[100px] px-[50px] shrink-0 w-fit"
                 aria-hidden="true"
               >
-                {MOCK_SHOWS.map((show) => (
-                  <div key={show.id}>
-                    <div
-                      className="w-[400px] h-[534px] rounded-[20px] bg-[#D9D9D9] bg-cover bg-center"
-                      style={{ backgroundImage: `url(${show.image})` }}
-                    ></div>
-                    <div className="flex flex-col gap-[20px]">
-                      <div className="flex flex-col gap-[10px] mt-[10px]">
-                        <h1 className="h1-bold">{show.title}</h1>
-                        <h2 className="h2-bold">{show.author}</h2>
-                      </div>
-                      <div className="flex flex-col gap-[10px]">
-                        <h2 className="h2-regular">{show.troupe}</h2>
-                        <h2 className="h2-regular">{show.period}</h2>
-                      </div>
-                    </div>
-                  </div>
-                ))}
+                <Page3_5Content />
               </div>
             </div>
           </section>

--- a/src/pages/MainVer2.tsx
+++ b/src/pages/MainVer2.tsx
@@ -34,6 +34,7 @@ import brunch from "../assets/image/landing/page4/brunch.svg";
 import "./MainVer2.scss";
 import "./MainVer2Page2.scss";
 import clsx from "clsx";
+import { MOCK_SHOWS } from "@/constants/ShowCard";
 
 const MainVer2 = () => {
   const [signUpToast, setSignUpToast] = useState<string>("");
@@ -287,6 +288,64 @@ const MainVer2 = () => {
         </div>
 
         <Page3 />
+
+        {/* Page 3.5. 공연된 작품 */}
+        <section className="pt-[97px] pb-[116px] w-full bg-[#F5F0FF]">
+          <h1 className="title_64px mb-[78px]">
+            포도상점의 작품이 공연되었어요
+          </h1>
+
+          <section className="relative w-full overflow-hidden group">
+            <div className="animate-slider-left inline-flex group-hover:[animation-play-state:paused]">
+              {/* 1번 트랙*/}
+              <div className="inline-flex gap-[100px] px-[50px] shrink-0 w-fit">
+                {MOCK_SHOWS.map((show) => (
+                  <div key={show.id}>
+                    <div
+                      className="w-[400px] h-[534px] rounded-[20px] bg-[#D9D9D9] bg-cover bg-center"
+                      style={{ backgroundImage: `url(${show.image})` }}
+                    ></div>
+                    <div className="flex flex-col gap-[20px]">
+                      <div className="flex flex-col gap-[10px] mt-[10px]">
+                        <h1 className="h1-bold">{show.title}</h1>
+                        <h2 className="h2-bold">{show.author}</h2>
+                      </div>
+                      <div className="flex flex-col gap-[10px]">
+                        <h2 className="h2-regular">{show.troupe}</h2>
+                        <h2 className="h2-regular">{show.period}</h2>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {/* 2번 트랙 */}
+              <div
+                className="inline-flex gap-[100px] px-[50px] shrink-0 w-fit"
+                aria-hidden="true"
+              >
+                {MOCK_SHOWS.map((show) => (
+                  <div key={show.id}>
+                    <div
+                      className="w-[400px] h-[534px] rounded-[20px] bg-[#D9D9D9] bg-cover bg-center"
+                      style={{ backgroundImage: `url(${show.image})` }}
+                    ></div>
+                    <div className="flex flex-col gap-[20px]">
+                      <div className="flex flex-col gap-[10px] mt-[10px]">
+                        <h1 className="h1-bold">{show.title}</h1>
+                        <h2 className="h2-bold">{show.author}</h2>
+                      </div>
+                      <div className="flex flex-col gap-[10px]">
+                        <h2 className="h2-regular">{show.troupe}</h2>
+                        <h2 className="h2-regular">{show.period}</h2>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+        </section>
 
         <div className=" page4 page-size">
           <div className=" page4-size">

--- a/src/pages/MainVer2Page2.scss
+++ b/src/pages/MainVer2Page2.scss
@@ -2,18 +2,17 @@
 
 .page2 {
   @include r.media-tablet {
-    margin: 270px auto 105px;
-    height: 1148px;
+    margin-top: 270px;
     width: 768px;
+    height: 1148px;
   }
   @include r.media-mobile {
     margin: 0;
-    height: 1148px;
     width: 468px;
+    height: fit-content;
   }
   @include r.media-small-mobile {
     width: 320px;
-    height: 723px;
   }
 }
 .main-ver2 .page2 .page2-title {
@@ -26,8 +25,6 @@
 
 .main-ver2 .page2 .page2-content-wrap {
   gap: 23px;
-
-  margin-bottom: 14.352vh; /* 155px */
   @include r.media-laptop {
     gap: 20px;
   }

--- a/src/pages/myPage/PostManage/PostManageDetail.tsx
+++ b/src/pages/myPage/PostManage/PostManageDetail.tsx
@@ -119,6 +119,8 @@ const PostManageDetail: React.FC = () => {
   const onClickModifyBtn = async () => {
     if (!scriptId || !accessToken) return;
     try {
+      setPartialLoading(true);
+      
       const formData = new FormData();
 
       formData.append("id", scriptId);
@@ -154,6 +156,7 @@ const PostManageDetail: React.FC = () => {
       }
 
       const success = await postWorkDetail(formData);
+      setPartialLoading(false);
 
       if (success) {
         toastAlert("작품 수정이 완료되었습니다.", "success");

--- a/src/pages/work/Detail.tsx
+++ b/src/pages/work/Detail.tsx
@@ -246,6 +246,12 @@ const Detail = () => {
     setIsOptionSelected(true);
   };
 
+  useEffect(() => {
+    if (selectedOption === "scriptPerform" || selectedOption === "perform") {
+      setShowPopup(true);
+    }
+  }, [selectedOption]);
+
   const onChangeBottomSelectOption = (
     event: React.ChangeEvent<HTMLSelectElement>
   ) => {
@@ -697,11 +703,7 @@ const Detail = () => {
                           >
                             <div className="flex items-center price-wrapper">
                               <p
-                                className={
-                                  !isSmallMobile
-                                    ? "p-large-medium"
-                                    : "p-xs-medium"
-                                }
+                                className="p-xs-medium sm:p-large-medium whitespace-nowrap"
                                 id="price"
                               >
                                 {formatPrice(script?.scriptPrice)} 원
@@ -764,11 +766,7 @@ const Detail = () => {
                           >
                             <div className="flex items-center price-wrapper">
                               <p
-                                className={
-                                  !isSmallMobile
-                                    ? "p-large-medium"
-                                    : "p-xs-medium"
-                                }
+                                className="p-xs-medium sm:p-large-medium whitespace-nowrap"
                                 id="price"
                               >
                                 {formatPrice(

--- a/src/styles/typography-headings.css
+++ b/src/styles/typography-headings.css
@@ -40,6 +40,18 @@
   letter-spacing: -0.64px;
 }
 
+@utility h2-regular {
+  color: #000;
+
+  /* H2/Regular */
+  font-family: Pretendard;
+  font-size: 32px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 40px; /* 125% */
+  letter-spacing: -0.64px;
+}
+
 @utility h3-regular {
   /* H3/Regular */
   font-size: 28px;


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요. -->

- #368 

## 📌 PR 내용

<!-- PR 내용을 설명해주세요. -->

- feat: 랜딩페이지 공연된 작품 interaction 추가
- feat: PostManageDetail 로딩 modal 추가
- chore: ServerURL git index 삭제 (.gitignore 처리)
- feat: 공연권 구매 선택 시 popup 튀어나오도록 추가
- design: Modal 화살표 disabled 시 opacity 0으로 변경

## 🗣️ 팀원에게 공유할 내용

다음부터는 PR 분리하겠습니다...

```tsx
{/* Page 2.5. 공연된 작품 */}
        <section className="py-[80px] sm:py-[135px] md:py-[150px] lg:py-[271px] w-full">
          <h1 className="title_64px mb-[30px] sm:mb-[78px]">
            포도상점의 작품이 공연되었어요
          </h1>

          <section className="relative w-full overflow-hidden group">
            <div className="animate-slider-left inline-flex group-hover:[animation-play-state:paused]">
              {/* 1번 트랙*/}
              <div className="inline-flex gap-[20px] md:gap-[45px] lg:gap-[100px] px-[10px] md:px-[22.5px] lg:px-[50px] shrink-0 w-fit">
                <Page2_5Content />
              </div>

              {/* 2번 트랙 */}
              <div
                className="inline-flex gap-[20px] md:gap-[45px] lg:gap-[100px] px-[10px] md:px-[22.5px] lg:px-[50px] shrink-0 w-fit"
                aria-hidden="true"
              >
                <Page2_5Content />
              </div>
            </div>
          </section>
        </section>
```
같은 트랙을 두 번 겹쳐 생성하여 무한한 스크롤 interaction을 구현하였습니다

<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->

## ✅ Check List

- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
- [ ] 코드 스타일을 eslint/prettier로 맞췄나요?
