### PR TITLE
feat: 스켈레톤 표시 개선 및 데이터 캐싱 로직 개선

### DIFF
--- a/src/api/user/postListApi.ts
+++ b/src/api/user/postListApi.ts
@@ -43,13 +43,14 @@ export const fetchExploreScripts = async (
 
     const response = await api.get<ExploreScriptsResponse>("/scripts", {
       headers,
-      withCredentials: true, // 쿠키 인증 시 필요
+      withCredentials: true,
       params: {
         sortType,
       },
     });
 
     const { longPlay, shortPlay } = response.data;
+
     return {
       longPlay: Array.isArray(longPlay) ? longPlay : [],
       shortPlay: Array.isArray(shortPlay) ? shortPlay : [],
@@ -60,7 +61,6 @@ export const fetchExploreScripts = async (
   }
 };
 
-// 좋아한 장편 작품 목록 조회
 export const getLongWorks = async (
   page: number = 0,
   accessToken?: string,
@@ -85,7 +85,6 @@ export const getLongWorks = async (
   }
 };
 
-// 좋아한 장편 작품 목록 조회
 export const getShortWorks = async (
   page: number = 0,
   accessToken?: string,


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요. -->

#271 


## 📌 PR 내용

<!-- PR 내용을 설명해주세요. -->

📌 주요 변경 사항
- 작품 둘러보기에서 탭 이동 시마다 발생하던 불필요한 API 호출을 제거하기 위해 최초 진입 시 데이터를 한 번만 호출하고 이후에는 캐싱된 데이터를 재사용하도록 로직을 수정했습니다.
- 작품둘러보기 화면 전환 시 사용자 경험을 개선하기 위해 Skeleton UI를 추가했습니다.


## 🗣️ 팀원에게 공유할 내용

<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->

## ✅ Check List

- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
- [ ] 코드 스타일을 eslint/prettier로 맞췄나요?
