### PR TITLE
feat: 대본 열람 pdf 화면 비율에 맞게 크기 조정 및 확대 로직 수정

### DIFF
--- a/src/pages/work/PostView.tsx
+++ b/src/pages/work/PostView.tsx
@@ -32,9 +32,7 @@ const PostView: React.FC = () => {
   const barHeight = window.innerHeight * 0.07; // 하단바 높이(px), 필요시 Tailwind 단위로 환산 가능
   const getPdfWidth = () => {
     const width = window.innerWidth;
-    if (width <= 320) return 320;
-    if (width <= 768) return width;
-    return 653;
+    return width;
   };
   const HEADER_HEIGHT = 179; // 헤더 높이
 
@@ -284,7 +282,7 @@ const PostView: React.FC = () => {
       const next =
         direction === "in"
           ? Math.min(2.0, +(prev + 0.1).toFixed(1))
-          : Math.max(0.8, +(prev - 0.1).toFixed(1));
+          : Math.max(0.5, +(prev - 0.1).toFixed(1));
       return next;
     });
 
@@ -335,7 +333,7 @@ const PostView: React.FC = () => {
           <span className="absolute z-100 w-[200vw] border border-[var(--purple7)] left-[-50%]" />
         </div>
 
-        <div className="relative w-full pt-[179px] ">
+        <div className="relative w-full pt-[179px]">
           {showWarningModal && (
             <>
               <WarningModal onClose={() => setShowWarningModal(false)} />
@@ -350,7 +348,7 @@ const PostView: React.FC = () => {
               >
                 {Array.from(new Array(numPages), (_, index) => (
                   <div
-                    className="z-0 "
+                    className="z-0"
                     id={`page-${index + 1}`}
                     key={`page-${index + 1}`}
                   >
@@ -414,11 +412,11 @@ const PostView: React.FC = () => {
                     >
                       <path
                         d="M13.5938 9.375H6.40625C6.32031 9.375 6.25 9.44531 6.25 9.53125V10.4688C6.25 10.5547 6.32031 10.625 6.40625 10.625H13.5938C13.6797 10.625 13.75 10.5547 13.75 10.4688V9.53125C13.75 9.44531 13.6797 9.375 13.5938 9.375Z"
-                        fill={`${scale === 0.8 ? "#BABABA" : "black"}`}
+                        fill={`${scale === 0.5 ? "#BABABA" : "black"}`}
                       />
                       <path
                         d="M10 1.25C5.16797 1.25 1.25 5.16797 1.25 10C1.25 14.832 5.16797 18.75 10 18.75C14.832 18.75 18.75 14.832 18.75 10C18.75 5.16797 14.832 1.25 10 1.25ZM10 17.2656C5.98828 17.2656 2.73438 14.0117 2.73438 10C2.73438 5.98828 5.98828 2.73438 10 2.73438C14.0117 2.73438 17.2656 5.98828 17.2656 10C17.2656 14.0117 14.0117 17.2656 10 17.2656Z"
-                        fill={`${scale === 0.8 ? "#BABABA" : "black"}`}
+                        fill={`${scale === 0.5 ? "#BABABA" : "black"}`}
                       />
                     </svg>
                   </button>


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요. -->

- #이슈번호
#395 
## 📌 PR 내용

<!-- PR 내용을 설명해주세요. -->

- pdf의 크기를 화면에 꽉 차도록 변경하였습니다.
- 이로 인해 기존 <Page/>에서 scale로 pdf 를 확대하니 확대 시 pdf 가 화면에서 넘치는 이슈가 생겼습니다. 따라서 width로 pdf 배율을 조정하고 가로 스크롤을 가능하도록 하여 이 문제를 해결하였습니다. 

## 🗣️ 팀원에게 공유할 내용

<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->

## ✅ Check List

- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
- [ ] 코드 스타일을 eslint/prettier로 맞췄나요?
