### PR TITLE
refactor: 주문 상태(orderStatus) 제거에 따른 전체 구매/환불 플로우 정리

### DIFF
--- a/src/components/myPage/PurchasedPerformBtn.jsx
+++ b/src/components/myPage/PurchasedPerformBtn.jsx
@@ -11,21 +11,19 @@ import "./../../styles/utilities.css";
  * @param {object} props
  * @param {number} props.id - id
  * @param {number} props.possibleCount - 공연 가능 횟수
- * @param {string} props.orderStatus - WAIT: 입금 확인 중, PASS: 결제 완료, REJECT: 결제 취소
  * @returns
  */
-const PurchasedPerformBtn = ({ id, possibleCount = 0, orderStatus = "WAIT", style }) => {
+const PurchasedPerformBtn = ({ id, possibleCount = 0, style }) => {
   const navigate = useNavigate();
   return (
     <div className="purchased-script-btn">
       <Button
-        disabled={orderStatus !== "PASS"}
         onClick={() => {
           navigate(`/mypage/purchased/performance-info/${id}`);
         }}
         style={style}
       >
-        {orderStatus === "PASS" ? "공연 신청 정보" : "입금 확인 중"}
+        공연 신청 정보
       </Button>
     </div>
   );

--- a/src/components/myPage/PurchasedPerformPossibleInfo.jsx
+++ b/src/components/myPage/PurchasedPerformPossibleInfo.jsx
@@ -7,22 +7,19 @@ const PurchasedPerformPossibleInfo = ({ script }) => {
   return (
     <div className="f-dir-column j-content-end">
       <p
-        className={`${!isSmallMobile ? "p-medium-regular" : "p-xs-regular"} ${
-          script.orderStatus === "PASS" ? "" : "c-grey4"
-        }`}
+        className={`${!isSmallMobile ? "p-medium-regular" : "p-xs-regular"}
+        `}
       >
         공연 가능 횟수 : {script.possibleCount} 번
       </p>
       <p
         className={`${
           !isSmallMobile ? "p-12-400" : "text-[8px] font-[400] leading-[14px]"
-        } t-underline ${
-          script.possibleCount !== 0 && script.orderStatus === "PASS"
-            ? "c-pointer"
-            : "c-grey4 c-default"
+        } t-underline  ${
+          script.possibleCount !== 0 ? "c-pointer" : "c-grey4 c-default"
         }`}
         onClick={() => {
-          if (script.possibleCount !== 0 && script.orderStatus === "PASS") {
+          if (script.possibleCount !== 0) {
             navigate(`/mypage/purchased/performance-refund/${script.id}`);
           }
         }}

--- a/src/components/myPage/PurchasedScriptBtn.jsx
+++ b/src/components/myPage/PurchasedScriptBtn.jsx
@@ -17,10 +17,15 @@ import "./../../styles/utilities.css";
  * @param {number} props.id - 구매 내역의 id
  * @param {number} props.productId - 작품의 개별 id
  * @param {number} props.buyPerformance - 0: 구매 불가, 1: 계약 필요, 2: 구매 가능 아이콘 추가
- * @param {string} props.orderStatus - WAIT: 입금 확인 중, PASS: 결제 완료, REJECT: 결제 취소
  * @returns
  */
-const PurchasedScriptBtn = ({ id, title, productId, buyPerformance, orderStatus = "WAIT", style }) => {
+const PurchasedScriptBtn = ({
+  id,
+  title,
+  productId,
+  buyPerformance,
+  style,
+}) => {
   const navigate = useNavigate();
 
   const onClickPurchasePerform = async () => {
@@ -68,8 +73,8 @@ const PurchasedScriptBtn = ({ id, title, productId, buyPerformance, orderStatus 
         </Button>
       ) : null}
 
-      <Button disabled={orderStatus !== "PASS"} onClick={onClickDownloadScript} style={style}>
-        {orderStatus === "PASS" ? "대본 받기" : "입금 확인 중"}
+      <Button onClick={onClickDownloadScript} style={style}>
+        대본 받기
       </Button>
     </div>
   );

--- a/src/components/myPage/ScriptContent.jsx
+++ b/src/components/myPage/ScriptContent.jsx
@@ -242,7 +242,6 @@ const ScriptContent = ({
                       title={script.title}
                       productId={script.productId}
                       buyPerformance={script.buyPerformance}
-                      orderStatus={script.orderStatus}
                       style={
                         isSmallMobile ? { width: "129px", height: "40px" } : {}
                       }

--- a/src/components/myPage/ScriptContent.jsx
+++ b/src/components/myPage/ScriptContent.jsx
@@ -258,7 +258,6 @@ const ScriptContent = ({
                       <Button
                         id={script.id}
                         possibleCount={script.possibleCount}
-                        orderStatus={script.orderStatus}
                       />
                     </section>
                   )


### PR DESCRIPTION
## 🔗 관련 이슈
- #이슈번호
#398 

## 📌 PR 내용
결제/구매 도메인에서 사용하던 orderStatus 필드를 제거함에 따라  
프론트엔드 전반에 걸쳐 존재하던 불필요한 분기 로직과 UI 조건문을 정리하는 작업을 하였습니다.

### 주요 변경 사항
- 구매한 대본/공연권에서 `orderStatus` 관련 로직 제거
- 버튼 노출 조건, 상태 분기 로직 등 중복된 UI 조건 삭제
- 어드민 주문 관리 페이지에서 주문 상태 표시 영역 정리  
  (단일 "주문 완료" 상태만 유지하도록 통합)
- API 응답 스펙 변경에 맞춰 타입 및 의존 로직 수정

### 개선 효과
- 주문/결제 플로우의 요구사항과 실제 UI 로직 간의 불일치 해소  
- 상태 분기 제거로 코드 복잡도 감소 및 유지보수성 향상  

## 🗣️ 팀원에게 공유할 내용
- 이전에 orderStatus 값에 따라 분기되던 로직은 모두 제거되었습니다.  
- 관리자 페이지도 동일한 규칙을 따르도록 반영해두었습니다.

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
- [ ] 코드 스타일을 eslint/prettier로 맞췄나요?
