### PR TITLE
fix: 환불 예정 공원 수량 ui 조건 수정

### DIFF
--- a/src/pages/myPage/PerformanceRefund.jsx
+++ b/src/pages/myPage/PerformanceRefund.jsx
@@ -39,7 +39,7 @@ const PerformanceRefund = () => {
   const [refundPossiblePrice, setRefundPossiblePrice] = useState(0);
 
   const [reason, setReason] = useState("");
-  const [currentAmount, setCurrentAmount] = useState(0);
+  const [currentAmount, setCurrentAmount] = useState(1);
   const [currentLength, setCurrentLength] = useState(0);
 
   const [showPopup, setShowPopup] = useState(false);


### PR DESCRIPTION
## 🔗 관련 이슈
- #이슈번호

## 📌 PR 내용
환불 예정 공연 초기 수량이 0 으로 되어있어 refundAmount가 0으로 보내져 "환불 가능 수량과 가격이 아님" 이라는 error 메시지를 받는 이슈가 있었습니다. 초기 수량을 1로 변경하였습니다.

### 주요 수정 사항
- 환불 예정 공연권 수량 계산 조건 정정
- 실제 환불 요청 데이터와 UI 표시 간 불일치 문제 해결

### 기대 효과
- 사용자에게 정확한 환불 예정 수량 제공  
- 환불 플로우에서 혼동이 줄어들어 UX 안정성 향상  
- 이후 결제/환불 정책 변경 시 영향 범위 축소

## 🗣️ 팀원에게 공유할 내용
## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
- [ ] 코드 스타일을 eslint/prettier로 맞췄나요?
