### PR TITLE
feat: 구매하기 request body에 user id 포함

### DIFF
--- a/src/pages/payment/Purchase.jsx
+++ b/src/pages/payment/Purchase.jsx
@@ -31,8 +31,10 @@ import "./Purchase.scss";
 import "./../../styles/utilities.css";
 import AmountChangePurchase from "@/components/detail/AmountChangePurchase";
 import PurchaseMethodBtn from "@/components/purchase/PurchaseMethodBtn";
+import AuthContext from "@/contexts/AuthContext";
 
 const Purchase = () => {
+  const { user } = useContext(AuthContext);
   const [thumbnailImg, setThumbnailImg] = useState("");
   const [title, setTitle] = useState("");
   const [author, setAuthor] = useState("");
@@ -203,7 +205,8 @@ const Purchase = () => {
           performanceAmount: buyPerform ? modifiedPurchasePerformAmount : 0,
         },
       ],
-      paymentMethod: payableAmount === 0 ? 0 : 1, // 0원: 0, 유료: 1
+      paymentMethod: payableAmount === 0 ? 0 : 1, // 0원: 0, 유료: 1,
+      userId: user?.id,
     };
 
     if (buyPerform) {


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요. -->

- #이슈번호
#398 
## 📌 PR 내용

<!-- PR 내용을 설명해주세요. -->

- 백엔드 요청 하에 구매하기 post /item body에 user id를 포함하였습니다.

## 🗣️ 팀원에게 공유할 내용
- 기존엔 토큰으로 구매 유저 정보를 db에 저장했었는데 나이스 페이 return url을 백 서버로 변경하면서 이것이 불가능하게 되어 프론트에서 user id 값을 보내주는 방식으로 결정하였습니다.
- 
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->

## ✅ Check List

- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
- [ ] 코드 스타일을 eslint/prettier로 맞췄나요?
