### PR TITLE
fix: Nicepay mallReserved 파라미터 이중 stringify 적용

### DIFF
--- a/src/pages/payment/Purchase.jsx
+++ b/src/pages/payment/Purchase.jsx
@@ -275,7 +275,7 @@ const Purchase = () => {
         amount: payableAmount,
         goodsName,
         returnUrl: `${SERVER_URL}order/item`,
-        mallReserved: JSON.stringify(requestBody),
+        mallReserved: JSON.stringify(JSON.stringify(requestBody)),
         fnError: (e) => {
           const msg = e?.errorMsg || "";
           // ❗ '결제 요청을 취소'는 에러 취급 X → 조용히 종료(재시도 가능)


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요. -->
- #398
## 📌 PR 내용

- Nicepay 결제 요청 시 mallReserved 값에 대해 백엔드/PG 스펙 요구에 맞춰 이중 stringify 적용

- 기존: JSON.stringify(requestBody)

- 변경: JSON.stringify(JSON.stringify(requestBody))

- PG 측 파싱 구조에 맞춰 mallReserved 값을 문자 그대로의 JSON 문자열로 전달하도록 수정

- 결제 요청(RequestPay) 로직에 mallReserved 인코딩 규칙 반영

## 🗣️ 팀원에게 공유할 내용

- mallReserved는 프론트에서 두 번 stringify하여 문자열 형태로 전달해야 백엔드에서 정상 파싱됨
(Nicepay/PODO 서버 구조에서 JSON → string → 다시 string 형태로 처리하기 때문)


## ✅ Check List

- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
- [ ] 코드 스타일을 eslint/prettier로 맞췄나요?
