### PR TITLE
fix: 결제 성공 페이지에서 orderId를 query param으로도 처리하도록 수정

### DIFF
--- a/src/pages/payment/Purchase.jsx
+++ b/src/pages/payment/Purchase.jsx
@@ -228,9 +228,9 @@ const Purchase = () => {
           }
         );
         const orderData = response.data[0];
-        navigate("/purchase/success", {
-          state: { orderId: orderData.id },
-        });
+        // navigate("/purchase/success", {
+        //   state: { orderId: orderData.id },
+        // });
         setIsLoading(false);
         return;
       }

--- a/src/pages/payment/PurchaseSuccess.jsx
+++ b/src/pages/payment/PurchaseSuccess.jsx
@@ -17,6 +17,14 @@ import "./PurchaseSuccess.css";
 import useWindowDimensions from "@/hooks/useWindowDimensions";
 
 const PurchaseSuccess = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const stateOrderId = location.state?.orderId;
+
+  const queryParams = new URLSearchParams(location.search);
+  const queryOrderId = queryParams.get("orderId");
+  const orderId = stateOrderId || queryOrderId;
+
   const [orderDate, setOrderDate] = useState("");
   const [scriptTitle, setScriptTitle] = useState("");
   const [buyScript, setBuyScript] = useState(false);
@@ -26,8 +34,6 @@ const PurchaseSuccess = () => {
 
   const [isLoading, setIsLoading] = useState(false);
 
-  const navigate = useNavigate();
-  const location = useLocation();
   const { orderId } = location.state || {};
   const { isSmallMobile } = useWindowDimensions().widthConditions;
 
@@ -63,6 +69,10 @@ const PurchaseSuccess = () => {
     return <Loading />;
   }
 
+  if (!orderId) {
+    // orderId가 정말 없으면 에러 처리 가능
+    return <div>잘못된 접근입니다.</div>;
+  }
   return (
     <div className="PurchaseSuccess">
       <div className="purchase-success">


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요. -->

- #398

## 📌 PR 내용

<!-- PR 내용을 설명해주세요. -->

1. 결제 성공 페이지 orderId 수신 방식 개선

- 기존: navigate("/purchase/success", { state: { orderId } }) 로 전달된 state만 사용

- 문제: 백엔드에서 /purchase/success?orderId=xxx 로 리다이렉트할 경우 orderId가 undefined가 됨

- 해결: state 값 우선 → 없으면 query param(?orderId=)에서 orderId를 가져오도록 로직 개선

- 두 방식 모두 지원함으로써 프론트/백엔드 모든 흐름 정상 동작

2. order/success API 호출 시 올바른 orderId 사용

- 파싱된 orderId가 존재할 때만 API 요청하도록 안정성 강화

- orderId 없음 시 에러 처리 추가 가능 (기본 안전장치)

## 🗣️ 팀원에게 공유할 내용

<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->

## ✅ Check List

- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
- [ ] 코드 스타일을 eslint/prettier로 맞췄나요?
