### PR TITLE
fix: 결제 페이지 이탈 시 나이스페이 결제 레이어 정리

### DIFF
--- a/src/pages/payment/Purchase.jsx
+++ b/src/pages/payment/Purchase.jsx
@@ -1,6 +1,6 @@
 import axios from "axios";
 import Cookies from "js-cookie";
-import { useEffect, useState, useContext } from "react";
+import { useCallback, useEffect, useRef, useState, useContext } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 
 import OnOffBtn from "../../components/button/OnOffBtn";
@@ -71,6 +71,7 @@ const Purchase = () => {
   const [buttonEnabled, setButtonEnabled] = useState(false);
 
   const [isLoading, setIsLoading] = useState(false);
+  const [isPayModalOpen, setIsPayModalOpen] = useState(false);
 
   const { id } = useParams();
   const location = useLocation();
@@ -86,6 +87,26 @@ const Purchase = () => {
 
   // NICEPAY SDK 로딩 상태
   const { ready: nicepayReady, requestPay } = useNicepay();
+
+  const closeNicepayLayer = useCallback(() => {
+    document.getElementById("newDivLayer")?.remove(); // 나이스페이가 body 밑에 직접 만든 div
+    document.querySelectorAll("iframe").forEach((el) => el.remove());
+    setIsPayModalOpen(false);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      closeNicepayLayer();
+    };
+  }, [closeNicepayLayer]);
+
+  useEffect(() => {
+    const onPopState = () => {
+      if (isPayModalOpen) closeNicepayLayer();
+    };
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, [isPayModalOpen, closeNicepayLayer]);
 
   useEffect(() => {
     if (name.length > 0 && name.trim() !== "") {
@@ -268,6 +289,7 @@ const Purchase = () => {
         JSON.stringify(requestBody)
       );
 
+      setIsPayModalOpen(true);
 
       requestPay({
         clientId: import.meta.env.VITE_NICEPAY_CLIENT_KEY,
@@ -282,11 +304,13 @@ const Purchase = () => {
           // ❗ '결제 요청을 취소'는 에러 취급 X → 조용히 종료(재시도 가능)
           if (msg.includes("결제 요청을 취소")) {
             setIsLoading(false);
+            setIsPayModalOpen(false);
             return;
           }
           console.log("결제창 에러:", msg);
           alert(`결제창 에러: ${msg || "알 수 없는 오류"}`);
           setIsLoading(false);
+          setIsPayModalOpen(false);
         },
         ...vbankOptions,
       });


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요. -->
- #420 

## 📌 PR 내용

<!-- PR 내용을 설명해주세요. -->

- 나이스 페이 결제 모듈 창 오픈 중에 뒤로가기 같은 이벤트가 발생해 페이지를 이탈하는 경우 나이스 페이 결제 모듈창이 닫히지 않는 오류가 있었는데 이를 해결하였습니다.

## 🗣️ 팀원에게 공유할 내용

<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->

## ✅ Check List

- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
- [ ] 코드 스타일을 eslint/prettier로 맞췄나요?
