### PR TITLE
feat: PerformanceRefund 팝업 모바일 버그 수정 및 PerformanceTop.scss 구조 변경에 따른 기타 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -119,6 +119,14 @@ function App() {
             path="mypage/scriptmanage"
             element={<ProtectedRoute element={<ScriptManage />} />}
           />
+          <Route
+            path="mypage/purchased/performance-refund/:id"
+            element={<ProtectedRoute element={<PerformanceRefund />} />}
+          />
+          <Route
+            path="mypage/purchased/performance-info/:id"
+            element={<ProtectedRoute element={<PerformanceInfo />} />}
+          />
 
           <Route path="mypage/info" element={<ProtectedRoute element={<AccountInfo />} />} />
           <Route
@@ -143,14 +151,6 @@ function App() {
             />
             <Route path="purchase/abort" element={<ProtectedRoute element={<Abort />} />} />
             <Route path="post" element={<PostWork />} />
-            <Route
-              path="mypage/purchased/performance-info/:id"
-              element={<ProtectedRoute element={<PerformanceInfo />} />}
-            />
-            <Route
-              path="mypage/purchased/performance-refund/:id"
-              element={<ProtectedRoute element={<PerformanceRefund />} />}
-            />
             <Route
               path="mypage/scriptmanage/detail/:scriptId"
               element={<ProtectedRoute element={<ScriptManageDetail />} />}

--- a/src/pages/myPage/AskedPerformManage.jsx
+++ b/src/pages/myPage/AskedPerformManage.jsx
@@ -16,14 +16,11 @@ import useWindowDimensions from "@/hooks/useWindowDimensions";
 import formatDateCutSec from "../../utils/formatDateCutSec";
 import { formatPrice } from "../../utils/formatPrice";
 
-import { SERVER_URL } from "../../constants/ServerURL";
-
 import listCloseBtn from "../../assets/image/button/listCloseBtn.svg";
 import listOpenBtn from "../../assets/image/button/listOpenBtn.svg";
 
 import "./AskedPerformManage.scss";
 import "./PerformanceTop.scss";
-import clsx from "clsx";
 
 const AskedPerformManage = () => {
   const [isExist, setIsExist] = useState(true);
@@ -79,73 +76,70 @@ const AskedPerformManage = () => {
     return <Loading />;
   }
 
-  const pLargeBoldClassName = !isSmallMobile ? "p-large-bold" : "p-small-bold";
-  const pSmallRegularClassName = !isSmallMobile ? "p-small-regular" : "p-xs-regular";
-
   return (
-    <div className="asked-perform-manage">
-      <div className="min-height perform-info perform-top">
+    <div className="asked-perform-manage perform-top">
+      <div className="min-height perform-info">
         <GoBack url="/mypage/scriptmanage" />
-        <h4 className={!isSmallMobile ? "h4-bold" : "p-medium-bold"}>
-          등록한 작품들을 관리할 수 있어요!
-        </h4>
+        <h4 className="p-medium-bold sm:h4-bold">등록한 작품들을 관리할 수 있어요!</h4>
 
-        <p className={!isSmallMobile ? "p-medium-regular" : "p-xs-regular"}>공연 신청 정보</p>
+        <p className="p-xs-regular sm:p-medium-regular">공연 신청 정보</p>
         <hr />
-        <div className=" contents">
-          <div className=" script-info f-dir-column a-items-center j-content-between">
-            <div className=" script-info-title f-dir-column a-items-center">
+        <div className="contents">
+          <div className="script-info flex flex-col items-center justify-between">
+            <div className="script-info-title flex flex-col items-center">
               <ThumbnailImg imagePath={productInfo.imagePath} />
-              <div style={{ height: "12px" }}></div>
-              <p className={pLargeBoldClassName}>{productInfo.title || "제목"}</p>
+              <div className="h-[12px]"></div>
+              <p className="p-small-bold sm:p-large-bold">{productInfo.title || "제목"}</p>
               <hr />
-              <p className={!isSmallMobile ? "p-large-medium" : "p-12-bold"}>
-                {productInfo.writer || "작가"}
-              </p>
-              <p className={clsx("summary t-center", pSmallRegularClassName)}>
+              <p className="p-12-bold sm:p-large-medium">{productInfo.writer || "작가"}</p>
+              <p className="summary text-center p-xs-regular sm:p-small-regular">
                 {productInfo.plot || "줄거리"}
               </p>
             </div>
-            <div className=" sales-status-box-wrap f-dir-column">
+            <div className="sales-status-box-wrap flex flex-col">
               <div className="sales-status-box">
-                <div className="title j-content-between a-items-end">
-                  <p className={pLargeBoldClassName}>대본</p>
+                <div className="title flex justify-between items-end">
+                  <p className="p-small-bold sm:p-large-bold">대본</p>
                   <ScriptManageEachTopBtn disabled={!productInfo.script}>
                     {!isSmallMobile && "대본"} {productInfo.script ? "판매 중" : "판매 중지"}
                   </ScriptManageEachTopBtn>
                 </div>
-                <div className="content j-content-center">
-                  <div className="sales-status-box-value f-dir-column a-items-center">
-                    <p className={pSmallRegularClassName}>
+                <div className="content flex justify-center items-center">
+                  <div className="sales-status-box-value flex flex-col items-center">
+                    <p className="p-xs-regular sm:p-small-regular">
                       {formatPrice(productInfo.scriptPrice)}원
                     </p>
-                    <p className={clsx("c-grey5", pSmallRegularClassName)}>가격</p>
+                    <p className="p-xs-regular sm:p-small-regular text-grey-5">가격</p>
                   </div>
                   <hr />
                   <div className="sales-status-box-value f-dir-column a-items-center">
-                    <p className={pSmallRegularClassName}>{productInfo.scriptQuantity}개</p>
-                    <p className={clsx("c-grey5", pSmallRegularClassName)}>판매 수</p>
+                    <p className="p-xs-regular sm:p-small-regular">
+                      {productInfo.scriptQuantity}개
+                    </p>
+                    <p className="p-xs-regular sm:p-small-regular text-grey-5">판매 수</p>
                   </div>
                 </div>
               </div>
               <div className="sales-status-box">
-                <div className="title j-content-between a-items-end">
-                  <p className={pLargeBoldClassName}>공연권</p>
+                <div className="title flex justify-between items-end">
+                  <p className="p-small-bold sm:p-large-bold">공연권</p>
                   <ScriptManageEachTopBtn disabled={!productInfo.performance}>
                     {!isSmallMobile && "공연권"} {productInfo.performance ? "판매 중" : "판매 중지"}
                   </ScriptManageEachTopBtn>
                 </div>
-                <div className="content j-content-center">
-                  <div className="sales-status-box-value f-dir-column a-items-center">
-                    <p className={pSmallRegularClassName}>
+                <div className="content flex justify-center">
+                  <div className="sales-status-box-value flex flex-col items-center">
+                    <p className="p-xs-regular sm:p-small-regular">
                       {formatPrice(productInfo.performancePrice)}원
                     </p>
-                    <p className={clsx("c-grey5", pSmallRegularClassName)}>가격</p>
+                    <p className="p-xs-regular sm:p-small-regular text-grey-5">가격</p>
                   </div>
                   <hr />
                   <div className="sales-status-box-value f-dir-column a-items-center">
-                    <p className={pSmallRegularClassName}>{productInfo.performanceQuantity}개</p>
-                    <p className={clsx("c-grey5", pSmallRegularClassName)}>판매 수</p>
+                    <p className="p-xs-regular sm:p-small-regular">
+                      {productInfo.performanceQuantity}개
+                    </p>
+                    <p className="p-xs-regular sm:p-small-regular text-grey-5">판매 수</p>
                   </div>
                 </div>
               </div>
@@ -160,10 +154,10 @@ const AskedPerformManage = () => {
                   style={index !== item.lists.length - 1 ? { marginBottom: "2.685vh" } : {}}
                 >
                   <div className="date flex justify-between items-center">
-                    <p className={clsx("text-[#8f8f8f]", pLargeBoldClassName)}>{item.date}</p>
+                    <p className=" p-small-bold sm:p-large-bold text-[#8f8f8f]">{item.date}</p>
                     {item.open ? (
                       <img
-                        className="c-pointer"
+                        className="cursor-pointer"
                         src={listCloseBtn}
                         alt="close"
                         onClick={() => {
@@ -174,7 +168,7 @@ const AskedPerformManage = () => {
                       />
                     ) : (
                       <img
-                        className="c-pointer"
+                        className="cursor-pointer"
                         src={listOpenBtn}
                         alt="open"
                         onClick={() => {
@@ -190,7 +184,7 @@ const AskedPerformManage = () => {
                       <div key={subIndex}>
                         <div className="content-inside">
                           <p className="p-medium-bold">신청자 정보</p>
-                          <div className="user-info j-content-between">
+                          <div className="user-info flex justify-between">
                             <ShortInputField value={subItem.name} readOnly={true} />
                             <ShortInputField value={subItem.phone} readOnly={true} />
                           </div>

--- a/src/pages/myPage/PerformanceInfo.jsx
+++ b/src/pages/myPage/PerformanceInfo.jsx
@@ -4,10 +4,7 @@ import { useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import GoBack from "../../components/button/GoBack.tsx";
-import {
-  PerformInputField,
-  PerformDateInputField,
-} from "../../components/inputField";
+import { PerformInputField, PerformDateInputField } from "../../components/inputField";
 import { CheckerMessage, ErrorMessage } from "../../components/auth/signUp";
 import SmallOnOffBtn from "../../components/button/RoundBtn_135_40";
 import InfoPopup from "../../components/popup/InfoPopup";
@@ -18,11 +15,7 @@ import useWindowDimensions from "../../hooks/useWindowDimensions";
 
 import formatDateCutSec from "../../utils/formatDateCutSec";
 
-import {
-  USER_INFO,
-  PERFORM_DATE,
-} from "../../constants/PopupTexts/PerformInfoTexts";
-import { SERVER_URL } from "../../constants/ServerURL";
+import { USER_INFO, PERFORM_DATE } from "../../constants/PopupTexts/PerformInfoTexts";
 
 import circleInfoBtn from "../../assets/image/button/circleInfoBtn.svg";
 import circleAddBtn from "../../assets/image/button/circleAddBtn.svg";
@@ -147,9 +140,7 @@ const PerformanceInfo = () => {
   const isDateOverThreeMonths = (date) => {
     const currentDate = dayjs(); // 현재 날짜
     const inputDate = dayjs(date); // 입력한 날짜
-    return (
-      inputDate.isValid() && inputDate.isAfter(currentDate.add(3, "month"))
-    ); // 3개월 이전인지 판단
+    return inputDate.isValid() && inputDate.isAfter(currentDate.add(3, "month")); // 3개월 이전인지 판단
   };
 
   const onClickDateInput = (index) => {
@@ -202,9 +193,7 @@ const PerformanceInfo = () => {
       alert("신청이 완료되었습니다.");
       navigate("/mypage/purchased");
     } catch (error) {
-      alert(
-        error.response.data.error || "오류가 발생했습니다. 다시 시도해주세요."
-      );
+      alert(error.response.data.error || "오류가 발생했습니다. 다시 시도해주세요.");
     }
   };
 
@@ -220,45 +209,32 @@ const PerformanceInfo = () => {
   }, [dates, inputFields.length]);
 
   return (
-    <div>
-      <div className="min-height perform-info perform-top">
+    <div className="perform-top">
+      <div className="min-height perform-info">
         <GoBack url="/mypage/purchased" />
-        <h4 className={!isSmallMobile ? "h4-bold" : "p-medium-bold"}>
-          구매한 작품들을 볼 수 있어요!
-        </h4>
+        <h4 className="p-medium-bold sm:h4-bold">구매한 작품들을 볼 수 있어요!</h4>
 
-        <p className={!isSmallMobile ? "p-medium-regular" : "p-xs-regular"}>
-          공연권 신청
-        </p>
+        <p className="p-xs-regular sm:p-medium-regular">공연권 신청</p>
         <hr />
-        <section className="f-dir-column a-items-center">
+        <section className="flex flex-col items-center">
           <div className="script">
-            <div className="d-flex">
+            <div className="flex gap-[15px] sm:gap-[32px]">
               <ThumbnailImg imagePath={thumbnail} />
               <div className="script-detail">
                 <div className="script-tag">
-                  <div className="d-flex a-items-center" id="title">
-                    <p
-                      className={
-                        !isSmallMobile ? "p-large-bold" : "p-small-bold"
-                      }
-                      id="title"
-                    >
+                  <div className="flex items-center" id="title">
+                    <p className="p-small-bold sm:p-large-bold" id="title">
                       {title}
                     </p>
                   </div>
                   <hr></hr>
-                  <p
-                    className={!isSmallMobile ? "p-large-medium" : "p-12-bold"}
-                    id="author"
-                  >
+                  <p className="p-12-bold sm:p-large-medium" id="author">
                     {author}
                   </p>
                   {!isSmallMobile && (
                     <p className="p-xs-regular" id="warning">
-                      * 공연권 사용 시 홍보물에 반드시 저작자의 이름과 대본이
-                      저작자의 것임을 표시해야 하며, 대본이 '포도상점'을 통하여
-                      제공되었음을 표시하여야 합니다.
+                      * 공연권 사용 시 홍보물에 반드시 저작자의 이름과 대본이 저작자의 것임을
+                      표시해야 하며, 대본이 '포도상점'을 통하여 제공되었음을 표시하여야 합니다.
                     </p>
                   )}
                 </div>
@@ -267,23 +243,17 @@ const PerformanceInfo = () => {
             {isSmallMobile && (
               <>
                 <p className="mt-[15px] px-[25px] p-xs-regular">
-                  * 공연권 사용 시 홍보물에 반드시 저작자의 이름과 대본이
-                  저작자의 것임을 표시해야 하며, 대본이 '포도상점'을 통하여
-                  제공되었음을 표시하여야 합니다.
+                  * 공연권 사용 시 홍보물에 반드시 저작자의 이름과 대본이 저작자의 것임을 표시해야
+                  하며, 대본이 '포도상점'을 통하여 제공되었음을 표시하여야 합니다.
                 </p>
-                <hr
-                  className="m-[0] mt-[15px]"
-                  style={{ borderColor: "#9E9E9E" }}
-                />
+                <hr className="m-[0] mt-[15px]" style={{ borderColor: "#9E9E9E" }} />
               </>
             )}
 
-            <div className="a-items-center" id="info">
-              <p className={!isSmallMobile ? "p-medium-bold" : "p-small-bold"}>
-                신청자 정보
-              </p>
+            <div className="flex items-center" id="info">
+              <p className="p-small-bold sm:p-medium-bold">신청자 정보</p>
               <img
-                className="c-pointer"
+                className="cursor-pointer"
                 id="popup-btn1"
                 src={circleInfoBtn}
                 alt="circleInfoBtn"
@@ -294,9 +264,7 @@ const PerformanceInfo = () => {
               {showPopup.userInfo ? (
                 <InfoPopup
                   message={USER_INFO}
-                  onClose={() =>
-                    setShowPopup({ ...showPopup, userInfo: false })
-                  }
+                  onClose={() => setShowPopup({ ...showPopup, userInfo: false })}
                   style={{
                     padding: "0.5rem 0.62rem",
                     left: "10px",
@@ -306,33 +274,17 @@ const PerformanceInfo = () => {
               ) : null}
             </div>
 
-            <PerformInputField
-              placeholder={applicantInfo.name}
-              readOnly={true}
-            />
+            <PerformInputField placeholder={applicantInfo.name} readOnly={true} />
             <div id="margin"></div>
-            <PerformInputField
-              placeholder={applicantInfo.phoneNumber}
-              readOnly={true}
-            />
+            <PerformInputField placeholder={applicantInfo.phoneNumber} readOnly={true} />
             <div id="margin"></div>
-            <PerformInputField
-              placeholder={applicantInfo.address}
-              readOnly={true}
-            />
+            <PerformInputField placeholder={applicantInfo.address} readOnly={true} />
 
-            <div
-              className="j-content-between a-items-center width-629"
-              id="days"
-            >
-              <div className="a-items-center" id="days-left">
-                <p
-                  className={!isSmallMobile ? "p-medium-bold" : "p-small-bold"}
-                >
-                  공연 예상 일자
-                </p>
+            <div className="flex justify-between items-center" id="days">
+              <div className="flex items-center" id="days-left">
+                <p className="p-small-bold sm:p-medium-bold">공연 예상 일자</p>
                 <img
-                  className="c-pointer"
+                  className="cursor-pointer"
                   id="popup-btn2"
                   src={circleInfoBtn}
                   alt="circleInfoBtn"
@@ -346,9 +298,7 @@ const PerformanceInfo = () => {
                 {showPopup.performDate ? (
                   <InfoPopup
                     message={PERFORM_DATE}
-                    onClose={() =>
-                      setShowPopup({ ...showPopup, performDate: false })
-                    }
+                    onClose={() => setShowPopup({ ...showPopup, performDate: false })}
                     style={{
                       padding: "0.5rem 0.62rem",
                       left: "24px",
@@ -403,13 +353,7 @@ const PerformanceInfo = () => {
                     onBlur={() => onBlurDateInput(index)}
                     onDelete={() => onDeleteField(index)} // X 버튼 클릭 시
                   />
-                  <div
-                    style={
-                      !dateChecker[index]?.show
-                        ? { height: "1rem" }
-                        : { height: "6px" }
-                    }
-                  ></div>
+                  <div className={!dateChecker[index]?.show ? "h-[1rem]" : "h-[6px]"}></div>
                   {/* dateChecker[index]?.show: optional chaining(없을 경우 undefined) */}
                   {dateChecker[index]?.show && (
                     <CheckerMessage
@@ -418,28 +362,26 @@ const PerformanceInfo = () => {
                     />
                   )}
                   {isDateOverThreeMonths(dates[index]) ? (
-                    <div style={{ marginTop: "5px" }}>
+                    <div className="mt-[5px]">
                       <ErrorMessage message="구매 시점으로부터 3개월 이내만 작성 가능해요." />
                     </div>
                   ) : null}
-                  <div
-                    style={!dateChecker[index]?.show ? {} : { height: "15px" }}
-                  ></div>
+                  <div className={!dateChecker[index]?.show ? "h-[0]" : "h-[15px]"}></div>
                 </div>
               ))}
 
             {performAmount - fetchedDates.length > 0 && (
-              <div className="j-content-center width-629" id="circle-add-btn">
+              <div className="flex justify-center" id="circle-add-btn">
                 <img
                   src={circleAddBtn}
                   alt="add"
-                  className="c-pointer"
+                  className="cursor-pointer"
                   onClick={onClickAddField}
                 />
               </div>
             )}
 
-            <div className="j-content-end width-629" id="btn">
+            <div className="flex justify-end" id="btn">
               <SmallOnOffBtn
                 color="white"
                 onClick={() => {
@@ -448,11 +390,7 @@ const PerformanceInfo = () => {
               >
                 취소하기
               </SmallOnOffBtn>
-              <SmallOnOffBtn
-                color="purple"
-                disabled={isApplyDisabled}
-                onClick={onClickApply}
-              >
+              <SmallOnOffBtn color="purple" disabled={isApplyDisabled} onClick={onClickApply}>
                 신청하기
               </SmallOnOffBtn>
             </div>

--- a/src/pages/myPage/PerformanceRefund.jsx
+++ b/src/pages/myPage/PerformanceRefund.jsx
@@ -98,33 +98,27 @@ const PerformanceRefund = () => {
     }
   };
 
-  const mediumBoldClassName = !isSmallMobile ? "p-medium-bold" : "p-xs-bold";
-  const mediumRegularClassName = !isSmallMobile ? "p-medium-regular" : "p-xs-regular";
-  const largeMediumClassName = !isSmallMobile ? "p-large-medium" : "p-xs-medium";
-
   return (
     <div>
       <div className="min-height perform-refund perform-top">
         <GoBack url="/mypage/purchased" />
-        <h4 className={!isSmallMobile ? "h4-bold" : "p-medium-bold"}>
-          구매한 작품들을 볼 수 있어요!
-        </h4>
+        <h4 className="p-medium-bold sm:h4-bold">구매한 작품들을 볼 수 있어요!</h4>
 
-        <p className={!isSmallMobile ? "p-medium-regular" : "p-xs-regular"}>공연권 환불 신청</p>
+        <p className="p-xs-regular sm:p-medium-regular">공연권 환불 신청</p>
         <hr />
-        <section className="f-dir-column a-items-center">
+        <section className="flex flex-col items-center">
           <div className="script">
-            <div className="d-flex">
+            <div className="flex">
               <ThumbnailImg imagePath={thumbnail} />
               <div className="script-detail">
                 <div className="script-tag">
-                  <div className="d-flex a-items-center" id="title">
-                    <p className={!isSmallMobile ? "p-large-bold" : "p-small-bold"} id="title">
+                  <div className="flex items-center" id="title">
+                    <p className="p-small-bold sm:p-large-bold" id="title">
                       {title}
                     </p>
                   </div>
                   <hr></hr>
-                  <p className={!isSmallMobile ? "p-large-medium" : "p-12-bold"} id="author">
+                  <p className="p-12-bold sm:p-large-medium" id="author">
                     {author}
                   </p>
                 </div>
@@ -134,47 +128,51 @@ const PerformanceRefund = () => {
             <hr />
 
             <div id="detail">
-              <div className="j-content-between detail-content">
-                <p className={clsx(mediumBoldClassName, "c-grey")}>구매 일자</p>
-                <p className={clsx(mediumRegularClassName, "c-grey")}>
+              <div className="detail-content flex justify-between">
+                <p className="p-xs-medium sm:p-medium-bold text-grey-6">구매 일자</p>
+                <p className="p-xs-regular sm:p-medium-regular text-grey-6">
                   {orderDate ? formatDate2(orderDate) : ""}
                 </p>
               </div>
               <hr />
-              <div className="j-content-between detail-content">
-                <p className={clsx(mediumBoldClassName, "c-grey")}>주문번호</p>
-                <p className={clsx(mediumRegularClassName, "c-grey")}>{orderNum}</p>
+              <div className="detail-content flex justify-between">
+                <p className="p-xs-medium sm:p-medium-bold text-grey-6">주문번호</p>
+                <p className="p-xs-regular sm:p-medium-regular text-grey-6">{orderNum}</p>
               </div>
               <hr />
-              <div className="j-content-between detail-content">
-                <p className={clsx(mediumBoldClassName, "c-grey")}>구매한 공연권 수량 및 금액</p>
-                <div className="j-content-end">
-                  <p className={clsx(largeMediumClassName, "c-grey")}>{orderedAmount}</p>
+              <div className="detail-content flex justify-between">
+                <p className="p-xs-medium sm:p-medium-bold text-grey-6">
+                  구매한 공연권 수량 및 금액
+                </p>
+                <div className="flex justify-end">
+                  <p className="p-xs-medium sm:p-large-medium text-grey-6">{orderedAmount}</p>
                   <div className="price-default-left" />
-                  <p className={clsx(largeMediumClassName, "c-grey price-default")}>
+                  <p className="price-default p-xs-medium sm:p-large-medium text-grey-6">
                     {formatPrice(orderedPrice)}원
                   </p>
                 </div>
               </div>
               <hr />
-              <div className="j-content-between detail-content">
-                <p className={clsx(mediumBoldClassName, "c-grey")}>
+              <div className="detail-content flex justify-between">
+                <p className="p-xs-medium sm:p-medium-bold text-grey-6">
                   환불 가능한 공연권 수량 및 금액
                 </p>
-                <div className="j-content-end">
-                  <p className={clsx(largeMediumClassName, "c-grey")}>{refundPossibleAmount}</p>
+                <div className="flex justify-end">
+                  <p className="p-xs-medium sm:p-large-medium text-grey-6">
+                    {refundPossibleAmount}
+                  </p>
                   <div className="price-default-left" />
-                  <p className={clsx(largeMediumClassName, "c-grey price-default")}>
+                  <p className="price-default p-xs-medium sm:p-large-medium text-grey-6">
                     {formatPrice(refundPossiblePrice)}원
                   </p>
                 </div>
               </div>
               <hr />
-              <div className="j-content-between a-items-center detail-content" id="total">
-                <p className={mediumBoldClassName}>환불 예정 공연권 수량 및 금액</p>
-                <div className="j-content-end a-items-center">
+              <div className="detail-content flex justify-between items-center" id="total">
+                <p className="p-xs-medium sm:p-medium-bold">환불 예정 공연권 수량 및 금액</p>
+                <div className="flex justify-end items-center">
                   {refundPossibleAmount !== 1 ? (
-                    <div className="j-content-between a-items-center" id="total-amount">
+                    <div className="flex justify-between items-center" id="total-amount">
                       <img
                         className="c-pointer"
                         src={minusBtn}
@@ -183,9 +181,7 @@ const PerformanceRefund = () => {
                           changeAmount(-1);
                         }}
                       />
-                      <p className={clsx(largeMediumClassName, "t-align-center")}>
-                        {currentAmount}
-                      </p>
+                      <p className="p-xs-medium sm:p-large-medium text-center">{currentAmount}</p>
                       <img
                         className="c-pointer"
                         src={plusBtn}
@@ -196,12 +192,12 @@ const PerformanceRefund = () => {
                       />
                     </div>
                   ) : (
-                    <div className="d-flex">
-                      <p className={largeMediumClassName}>{currentAmount}</p>
+                    <div className="flex">
+                      <p className="p-xs-medium sm:p-large-medium">{currentAmount}</p>
                       <div className="price-default-left" />
                     </div>
                   )}
-                  <p className={clsx(largeMediumClassName, "price-default")}>
+                  <p className="price-default p-xs-medium sm:p-large-medium">
                     {formatPrice(singlePrice * currentAmount)}원
                   </p>
                 </div>
@@ -209,10 +205,10 @@ const PerformanceRefund = () => {
             </div>
 
             <hr />
-            <div className="j-content-between a-items-center">
-              <p className={!isSmallMobile ? "p-medium-bold" : "p-small-bold"}>환불 사유</p>
+            <div className="flex justify-between items-center">
+              <p className="p-small-bold sm:p-medium-bold">환불 사유</p>
             </div>
-            <div style={{ height: "0.63rem" }} />
+            <div className="h-[0.63rem]" />
             <PerformInputField
               placeholder="자유롭게 입력해주세요."
               value={reason}
@@ -234,7 +230,7 @@ const PerformanceRefund = () => {
               }
             />
 
-            <div className="j-content-end" id="btn">
+            <div className="flex justify-end" id="btn">
               <SmallOnOffBtn
                 color="white"
                 onClick={() => {
@@ -259,7 +255,7 @@ const PerformanceRefund = () => {
                 신청하기
               </SmallOnOffBtn>
             </div>
-            {!showPopup ? (
+            {showPopup ? (
               <div className="refund-popup flex flex-col justify-center text-center p-small-bold sm:p-medium-bold">
                 <p>환불 신청이 완료되었어요.</p>
                 <p>

--- a/src/pages/myPage/PerformanceRefund.jsx
+++ b/src/pages/myPage/PerformanceRefund.jsx
@@ -99,12 +99,8 @@ const PerformanceRefund = () => {
   };
 
   const mediumBoldClassName = !isSmallMobile ? "p-medium-bold" : "p-xs-bold";
-  const mediumRegularClassName = !isSmallMobile
-    ? "p-medium-regular"
-    : "p-xs-regular";
-  const largeMediumClassName = !isSmallMobile
-    ? "p-large-medium"
-    : "p-xs-medium";
+  const mediumRegularClassName = !isSmallMobile ? "p-medium-regular" : "p-xs-regular";
+  const largeMediumClassName = !isSmallMobile ? "p-large-medium" : "p-xs-medium";
 
   return (
     <div>
@@ -114,9 +110,7 @@ const PerformanceRefund = () => {
           구매한 작품들을 볼 수 있어요!
         </h4>
 
-        <p className={!isSmallMobile ? "p-medium-regular" : "p-xs-regular"}>
-          공연권 환불 신청
-        </p>
+        <p className={!isSmallMobile ? "p-medium-regular" : "p-xs-regular"}>공연권 환불 신청</p>
         <hr />
         <section className="f-dir-column a-items-center">
           <div className="script">
@@ -125,20 +119,12 @@ const PerformanceRefund = () => {
               <div className="script-detail">
                 <div className="script-tag">
                   <div className="d-flex a-items-center" id="title">
-                    <p
-                      className={
-                        !isSmallMobile ? "p-large-bold" : "p-small-bold"
-                      }
-                      id="title"
-                    >
+                    <p className={!isSmallMobile ? "p-large-bold" : "p-small-bold"} id="title">
                       {title}
                     </p>
                   </div>
                   <hr></hr>
-                  <p
-                    className={!isSmallMobile ? "p-large-medium" : "p-12-bold"}
-                    id="author"
-                  >
+                  <p className={!isSmallMobile ? "p-large-medium" : "p-12-bold"} id="author">
                     {author}
                   </p>
                 </div>
@@ -157,26 +143,15 @@ const PerformanceRefund = () => {
               <hr />
               <div className="j-content-between detail-content">
                 <p className={clsx(mediumBoldClassName, "c-grey")}>주문번호</p>
-                <p className={clsx(mediumRegularClassName, "c-grey")}>
-                  {orderNum}
-                </p>
+                <p className={clsx(mediumRegularClassName, "c-grey")}>{orderNum}</p>
               </div>
               <hr />
               <div className="j-content-between detail-content">
-                <p className={clsx(mediumBoldClassName, "c-grey")}>
-                  구매한 공연권 수량 및 금액
-                </p>
+                <p className={clsx(mediumBoldClassName, "c-grey")}>구매한 공연권 수량 및 금액</p>
                 <div className="j-content-end">
-                  <p className={clsx(largeMediumClassName, "c-grey")}>
-                    {orderedAmount}
-                  </p>
+                  <p className={clsx(largeMediumClassName, "c-grey")}>{orderedAmount}</p>
                   <div className="price-default-left" />
-                  <p
-                    className={clsx(
-                      largeMediumClassName,
-                      "c-grey price-default"
-                    )}
-                  >
+                  <p className={clsx(largeMediumClassName, "c-grey price-default")}>
                     {formatPrice(orderedPrice)}원
                   </p>
                 </div>
@@ -187,34 +162,19 @@ const PerformanceRefund = () => {
                   환불 가능한 공연권 수량 및 금액
                 </p>
                 <div className="j-content-end">
-                  <p className={clsx(largeMediumClassName, "c-grey")}>
-                    {refundPossibleAmount}
-                  </p>
+                  <p className={clsx(largeMediumClassName, "c-grey")}>{refundPossibleAmount}</p>
                   <div className="price-default-left" />
-                  <p
-                    className={clsx(
-                      largeMediumClassName,
-                      "c-grey price-default"
-                    )}
-                  >
+                  <p className={clsx(largeMediumClassName, "c-grey price-default")}>
                     {formatPrice(refundPossiblePrice)}원
                   </p>
                 </div>
               </div>
               <hr />
-              <div
-                className="j-content-between a-items-center detail-content"
-                id="total"
-              >
-                <p className={mediumBoldClassName}>
-                  환불 예정 공연권 수량 및 금액
-                </p>
+              <div className="j-content-between a-items-center detail-content" id="total">
+                <p className={mediumBoldClassName}>환불 예정 공연권 수량 및 금액</p>
                 <div className="j-content-end a-items-center">
                   {refundPossibleAmount !== 1 ? (
-                    <div
-                      className="j-content-between a-items-center"
-                      id="total-amount"
-                    >
+                    <div className="j-content-between a-items-center" id="total-amount">
                       <img
                         className="c-pointer"
                         src={minusBtn}
@@ -223,9 +183,7 @@ const PerformanceRefund = () => {
                           changeAmount(-1);
                         }}
                       />
-                      <p
-                        className={clsx(largeMediumClassName, "t-align-center")}
-                      >
+                      <p className={clsx(largeMediumClassName, "t-align-center")}>
                         {currentAmount}
                       </p>
                       <img
@@ -252,9 +210,7 @@ const PerformanceRefund = () => {
 
             <hr />
             <div className="j-content-between a-items-center">
-              <p className={!isSmallMobile ? "p-medium-bold" : "p-small-bold"}>
-                환불 사유
-              </p>
+              <p className={!isSmallMobile ? "p-medium-bold" : "p-small-bold"}>환불 사유</p>
             </div>
             <div style={{ height: "0.63rem" }} />
             <PerformInputField
@@ -303,21 +259,18 @@ const PerformanceRefund = () => {
                 신청하기
               </SmallOnOffBtn>
             </div>
-            {showPopup ? (
-              <div className="f-dir-column j-content-center" id="refund-popup">
+            {!showPopup ? (
+              <div className="refund-popup flex flex-col justify-center text-center p-small-bold sm:p-medium-bold">
                 <p>환불 신청이 완료되었어요.</p>
-                <div className="d-flex">
-                  <p>환불에는 영업일 기준&nbsp;</p>
-                  <p className="c-main">2-4일</p>
-                  <p>&nbsp;이 필요해요.</p>
-                </div>
+                <p>
+                  환불에는 영업일 기준&nbsp;<span className="text-main">2-4일</span>이 필요해요.
+                </p>
                 <p>환불이 완료되면 저장된 메일 주소로</p>
-                <div className="d-flex">
-                  <p className="c-main">환불 완료 메일</p>
-                  <p>을 보내드리니 확인 부탁드려요.</p>
-                </div>
+                <p>
+                  <span className="text-main">환불 완료 메일</span>을 보내드리니 확인 부탁드려요.
+                </p>
 
-                <div className="j-content-center" id="bottom-btn-wrap">
+                <div className="flex justify-center mt-[26px]">
                   <OnOffBtn
                     text="구매한 작품으로 돌아가기"
                     color="purple"

--- a/src/pages/myPage/PerformanceRefund.jsx
+++ b/src/pages/myPage/PerformanceRefund.jsx
@@ -14,8 +14,6 @@ import useWindowDimensions from "@/hooks/useWindowDimensions.ts";
 import { formatPrice } from "../../utils/formatPrice";
 import formatDate2 from "../../utils/formatDate2";
 
-import { SERVER_URL } from "../../constants/ServerURL";
-
 import plusBtn from "../../assets/image/button/circleAddBtn.svg";
 import minusBtn from "../../assets/image/button/circleSubBtn.svg";
 
@@ -23,7 +21,6 @@ import "./PerformanceRefund.scss";
 import "./PerformanceTop.scss";
 import "./../../styles/text.css";
 import "./../../styles/utilities.css";
-import clsx from "clsx";
 
 const PerformanceRefund = () => {
   const [thumbnail, setThumbnail] = useState("");
@@ -45,7 +42,6 @@ const PerformanceRefund = () => {
 
   const navigate = useNavigate();
   const { id } = useParams();
-  const { isSmallMobile } = useWindowDimensions().widthConditions;
 
   const MAX_LENGTH = 50;
 
@@ -99,8 +95,8 @@ const PerformanceRefund = () => {
   };
 
   return (
-    <div>
-      <div className="min-height perform-refund perform-top">
+    <div className="perform-top">
+      <div className="min-height perform-refund">
         <GoBack url="/mypage/purchased" />
         <h4 className="p-medium-bold sm:h4-bold">구매한 작품들을 볼 수 있어요!</h4>
 
@@ -108,7 +104,7 @@ const PerformanceRefund = () => {
         <hr />
         <section className="flex flex-col items-center">
           <div className="script">
-            <div className="flex">
+            <div className="flex gap-[15px] sm:gap-[32px]">
               <ThumbnailImg imagePath={thumbnail} />
               <div className="script-detail">
                 <div className="script-tag">
@@ -174,7 +170,7 @@ const PerformanceRefund = () => {
                   {refundPossibleAmount !== 1 ? (
                     <div className="flex justify-between items-center" id="total-amount">
                       <img
-                        className="c-pointer"
+                        className="cursor-pointer"
                         src={minusBtn}
                         alt="minusBtn"
                         onClick={() => {
@@ -183,7 +179,7 @@ const PerformanceRefund = () => {
                       />
                       <p className="p-xs-medium sm:p-large-medium text-center">{currentAmount}</p>
                       <img
-                        className="c-pointer"
+                        className="cursor-pointer"
                         src={plusBtn}
                         alt="plusBtn"
                         onClick={() => {
@@ -224,7 +220,7 @@ const PerformanceRefund = () => {
                 }
               }}
               rightElement={
-                <p className="p-xs-medium c-default" id="length">
+                <p className="p-xs-medium cursor-default" id="length">
                   {currentLength} / {MAX_LENGTH}
                 </p>
               }

--- a/src/pages/myPage/PerformanceRefund.scss
+++ b/src/pages/myPage/PerformanceRefund.scss
@@ -18,6 +18,7 @@
 /* PerformanceRefund css */
 .perform-refund .script > hr {
   margin-top: 2.5vh;
+  margin-bottom: 6px;
 }
 
 .perform-refund div#detail {

--- a/src/pages/myPage/PerformanceRefund.scss
+++ b/src/pages/myPage/PerformanceRefund.scss
@@ -87,33 +87,23 @@
   margin-top: 7.5vh;
 }
 
-.perform-refund div#refund-popup {
-  padding: 0 24px;
+.perform-refund .refund-popup {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
   padding-top: 42px;
   padding-bottom: 23px;
 
-  position: absolute; /* 부모 요소를 기준으로 절대 위치 */
-  top: 50%; /* 화면의 50% 지점으로 설정 */
-  left: 50%; /* 화면의 50% 지점으로 설정 */
-  transform: translate(-50%, -50%);
+  width: 350px;
 
   border-radius: 20px;
   background: var(--grey-grey-1, #fbfbfb);
   box-shadow: 0px 0px 20px 0px rgba(0, 0, 0, 0.25);
   z-index: 1000;
-}
 
-.perform-refund div#refund-popup p {
-  text-align: center;
-
-  /* Paragraph/Medium/Bold */
-  font-family: "Noto Sans KR";
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 24px; /* 150% */
-}
-
-.perform-refund div#refund-popup div#bottom-btn-wrap {
-  margin-top: 26px;
+  @include r.media-small-mobile {
+    width: 280px;
+  }
 }

--- a/src/pages/myPage/PerformanceTop.scss
+++ b/src/pages/myPage/PerformanceTop.scss
@@ -1,6 +1,20 @@
 @use "./../../styles/_responsive.scss" as r;
 
 .perform-top {
+  margin: 0 auto;
+  padding: 0 50px;
+
+  max-width: 1280px;
+
+  @include r.media-mobile {
+    padding: 0 25px;
+  }
+  @include r.media-small-mobile {
+    padding: 0 20px;
+  }
+}
+
+.perform-top > * {
   margin: 3.426vh 0;
 }
 
@@ -17,12 +31,13 @@
   margin-top: 3.241vh;
   margin-bottom: 1.75rem;
 
-  width: 629px;
+  width: 100%;
+  max-width: 630px;
   @include r.media-mobile {
-    width: 430px;
+    padding: 0;
   }
   @include r.media-small-mobile {
-    width: 280px;
+    padding: 0 5px;
   }
 }
 
@@ -31,15 +46,7 @@
   flex-direction: column;
   justify-content: space-between;
 
-  margin-left: 2rem;
-
-  width: 349px;
-  @include r.media-mobile {
-    width: 205px;
-  }
-  @include r.media-small-mobile {
-    margin-left: 15px;
-  }
+  flex: 1;
 }
 
 .perform-top .script-detail div#title {


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요. -->

- #433 

## 📌 PR 내용

<!-- PR 내용을 설명해주세요. -->

- [fix: PerformanceRefund 팝업 모바일 레이아웃 깨짐 수정](https://github.com/Podo-Store/FE/commit/74a184eabd12c5aa32dea38a05b663e7a5b28faa)


- [refactor: PerformanceRefund Tailwind 스타일로 변경](https://github.com/Podo-Store/FE/commit/fb67462d77ed05627d448995598fd9ef58434663) 

  - Tailwind 스타일로 변경
  - hr 하단 margin 추가
  
- [feat: PerformanceTop.scss 구조 변경 및 기타 수정](https://github.com/Podo-Store/FE/commit/bee073448acc7ddc1748ffc05e1fd0f3003fc2b6) 

  - PerformanceTop.scss 수정, 영향 페이지:
      - `PerformanceInfo.jsx`
      - `PerformanceRefund.jsx`
      - `AskedPerformManage.jsx`
  - 세 페이지 스타일 형태 Tailwind + SCSS로 획일화 (기존 util class 제거)
  - PerformanceRefund, PerformanceInfo MarginLayout -> DefaultLayout 이동
  - PerformanceRefund, PerformanceInfo 반응형 유연화

## 🗣️ 팀원에게 공유할 내용

<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->

## ✅ Check List

- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
- [ ] 코드 스타일을 eslint/prettier로 맞췄나요?
